### PR TITLE
remove ACCESS_BACKGROUND_LOCATION

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 


### PR DESCRIPTION
Remove permission for ACCESS_BACKGROUND_LOCATION from Manifest.

This shouldn't be required for our use of lib_proofmode, since we only "proof" files upon upload when the app is open whereas the Proofmode app itself does so in the background when you're taking pictures.