### PR TITLE
🖌 add theme selection settings

### DIFF
--- a/app/src/main/java/net/opendasharchive/openarchive/OpenArchiveApp.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/OpenArchiveApp.kt
@@ -11,6 +11,7 @@ import com.orm.SugarApp
 import info.guardianproject.netcipher.proxy.OrbotHelper
 import net.opendasharchive.openarchive.publish.PublishService
 import net.opendasharchive.openarchive.util.Prefs
+import net.opendasharchive.openarchive.util.ThemeHelper
 import timber.log.Timber
 
 class OpenArchiveApp : SugarApp() {
@@ -38,6 +39,8 @@ class OpenArchiveApp : SugarApp() {
         Prefs.trackLocation = false
 
         if (Prefs.useTor) initNetCipher()
+
+        ThemeHelper.setTheme(this, Prefs.theme)
     }
 
     /**

--- a/app/src/main/java/net/opendasharchive/openarchive/features/settings/SettingsActivity.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/settings/SettingsActivity.kt
@@ -23,6 +23,7 @@ import net.opendasharchive.openarchive.features.core.BaseActivity
 import net.opendasharchive.openarchive.util.AlertHelper
 import net.opendasharchive.openarchive.util.Hbks
 import net.opendasharchive.openarchive.util.Prefs
+import net.opendasharchive.openarchive.util.ThemeHelper
 import org.witness.proofmode.crypto.pgp.PgpUtils
 import timber.log.Timber
 import java.io.IOException
@@ -68,6 +69,7 @@ class SettingsActivity : BaseActivity() {
         const val KEY_DATAUSE = "datause"
         const val KEY_METADATA = "metadata"
         const val KEY_NETWORKING = "networking"
+        const val KEY_USER_INTERFACE = "user_interface"
 
         class SettingsFragment : PreferenceFragmentCompat() {
             override fun onCreatePreferences(bundle: Bundle?, s: String?) {
@@ -181,6 +183,15 @@ class SettingsActivity : BaseActivity() {
                             }
                         }
 
+                        true
+                    }
+                }
+                else if (type == KEY_USER_INTERFACE) {
+                    addPreferencesFromResource(R.xml.app_prefs_user_interface)
+
+                    findPreference<Preference>("theme")?.setOnPreferenceChangeListener { _, newValue ->
+                        val activity = activity ?: return@setOnPreferenceChangeListener true
+                        ThemeHelper.setTheme(activity.applicationContext, newValue as String)
                         true
                     }
                 }

--- a/app/src/main/java/net/opendasharchive/openarchive/features/settings/SpaceSettingsActivity.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/settings/SpaceSettingsActivity.kt
@@ -93,6 +93,12 @@ class SpaceSettingsActivity : AppCompatActivity() {
                 startActivity(intent)
             }
 
+            contentSpaceLayout.btnUserInterface.setOnClickListener {
+                val intent = Intent(this@SpaceSettingsActivity, SettingsActivity::class.java)
+                intent.putExtra(SettingsActivity.KEY_TYPE, SettingsActivity.KEY_USER_INTERFACE)
+                startActivity(intent)
+            }
+
             contentSpaceLayout.btnPrivacy.setOnClickListener {
                 openBrowser("https://open-archive.org/privacy")
             }

--- a/app/src/main/java/net/opendasharchive/openarchive/util/Prefs.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/util/Prefs.kt
@@ -2,11 +2,14 @@ package net.opendasharchive.openarchive.util
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.content.res.Resources
 import android.util.Base64
 import androidx.preference.PreferenceManager
+import net.opendasharchive.openarchive.R
 import org.witness.proofmode.ProofMode
+import java.lang.ref.WeakReference
 
-object Prefs{
+object Prefs {
 
     private const val UPLOAD_WIFI_ONLY = "upload_wifi_only"
     private const val NEARBY_USE_BLUETOOTH = "nearby_use_bluetooth"
@@ -25,8 +28,10 @@ object Prefs{
     private const val PROOFMODE_ENCRYPTED_PASSPHRASE = "proof_mode_encrypted_passphrase"
 
     private var prefs: SharedPreferences? = null
+    private lateinit var resources: Resources
 
     fun load(context: Context) {
+        resources = context.applicationContext.resources
         if (prefs == null) prefs = PreferenceManager.getDefaultSharedPreferences(context)
     }
 
@@ -121,17 +126,25 @@ object Prefs{
             return Base64.decode(passphrase, Base64.DEFAULT)
         }
         set(value) {
-            val passphrase = if (value == null) null else Base64.encodeToString(value, Base64.DEFAULT)
+            val passphrase =
+                if (value == null) null else Base64.encodeToString(value, Base64.DEFAULT)
 
             prefs?.edit()?.putString(PROOFMODE_ENCRYPTED_PASSPHRASE, passphrase)?.apply()
         }
 
     var theme: String
-        get() = prefs?.getString(PREF_THEME, null) ?: "system"
+        get() {
+            return prefs?.getString(PREF_THEME, null)
+                ?: resources.getString(R.string.prefs_theme_val_system)
+        }
         set(value) {
             var v: String = value
-            if (!arrayOf("light", "dark").contains(value)) {
-                v = "system"
+            if (!arrayOf(
+                    resources.getString(R.string.prefs_theme_val_light),
+                    resources.getString(R.string.prefs_theme_val_dark)
+                ).contains(value)
+            ) {
+                v = resources.getString(R.string.prefs_theme_val_system)
             }
             prefs?.edit()?.putString(PREF_THEME, v)?.apply()
         }

--- a/app/src/main/java/net/opendasharchive/openarchive/util/Prefs.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/util/Prefs.kt
@@ -14,6 +14,7 @@ object Prefs{
     private const val USE_TOR = "use_tor"
     private const val USE_PROOFMODE = "use_proofmode"
     private const val USE_NEXTCLOUD_CHUNKING = "upload_nextcloud_chunks"
+    private const val PREF_THEME = "theme"
     private const val CURRENT_SPACE_ID = "current_space"
     private const val FLAG_HINT_SHOWN = "ft.flag"
     private const val BATCH_HINT_SHOWN = "ft.batch"
@@ -123,5 +124,15 @@ object Prefs{
             val passphrase = if (value == null) null else Base64.encodeToString(value, Base64.DEFAULT)
 
             prefs?.edit()?.putString(PROOFMODE_ENCRYPTED_PASSPHRASE, passphrase)?.apply()
+        }
+
+    var theme: String
+        get() = prefs?.getString(PREF_THEME, null) ?: "system"
+        set(value) {
+            var v: String = value
+            if (!arrayOf("light", "dark").contains(value)) {
+                v = "system"
+            }
+            prefs?.edit()?.putString(PREF_THEME, v)?.apply()
         }
 }

--- a/app/src/main/java/net/opendasharchive/openarchive/util/ThemeHelper.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/util/ThemeHelper.kt
@@ -4,15 +4,13 @@ import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
 import net.opendasharchive.openarchive.R
 
-class ThemeHelper {
-    companion object {
-        fun setTheme(context: Context, theme: String)  {
-            val mode = when(theme) {
-                context.getString(R.string.prefs_theme_val_light) -> AppCompatDelegate.MODE_NIGHT_NO;
-                context.getString(R.string.prefs_theme_val_dark) -> AppCompatDelegate.MODE_NIGHT_YES;
-                else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
-            }
-            AppCompatDelegate.setDefaultNightMode(mode);
-        };
-    }
+object ThemeHelper {
+    fun setTheme(context: Context, theme: String) {
+        val mode = when (theme) {
+            context.getString(R.string.prefs_theme_val_light) -> AppCompatDelegate.MODE_NIGHT_NO;
+            context.getString(R.string.prefs_theme_val_dark) -> AppCompatDelegate.MODE_NIGHT_YES;
+            else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
+        }
+        AppCompatDelegate.setDefaultNightMode(mode);
+    };
 }

--- a/app/src/main/java/net/opendasharchive/openarchive/util/ThemeHelper.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/util/ThemeHelper.kt
@@ -1,0 +1,18 @@
+package net.opendasharchive.openarchive.util
+
+import android.content.Context
+import androidx.appcompat.app.AppCompatDelegate
+import net.opendasharchive.openarchive.R
+
+class ThemeHelper {
+    companion object {
+        fun setTheme(context: Context, theme: String)  {
+            val mode = when(theme) {
+                context.getString(R.string.prefs_theme_val_light) -> AppCompatDelegate.MODE_NIGHT_NO;
+                context.getString(R.string.prefs_theme_val_dark) -> AppCompatDelegate.MODE_NIGHT_YES;
+                else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
+            }
+            AppCompatDelegate.setDefaultNightMode(mode);
+        };
+    }
+}

--- a/app/src/main/res/layout/content_space_settings.xml
+++ b/app/src/main/res/layout/content_space_settings.xml
@@ -97,6 +97,14 @@
             android:textSize="22sp" />
 
         <TextView
+            android:id="@+id/btnUserInterface"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="@string/user_interface"
+            android:textSize="22sp" />
+
+        <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="18dp"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -12,4 +12,14 @@
         <item>@string/drawer_about</item>
         <item>@string/drawer_settings</item>
     </string-array>
+    <string-array name="ar_prefs_theme_val">
+        <item>@string/prefs_theme_val_system</item>
+        <item>@string/prefs_theme_val_light</item>
+        <item>@string/prefs_theme_val_dark</item>
+    </string-array>
+    <string-array name="ar_prefs_theme_labels">
+        <item>@string/prefs_theme_system</item>
+        <item>@string/prefs_theme_light</item>
+        <item>@string/prefs_theme_dark</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -176,6 +176,16 @@
     <string name="prefs_upload_wifi_only_summary">Wait for Wi-Fi to upload media</string>
     <string name="prefs_nearby_title">Nearby</string>
 
+    <string name="prefs_user_interface_title">User Interface</string>
+    <string name="prefs_theme_title">Select Theme</string>
+    <string name="prefs_theme_summary">Change how Safe looks.</string>
+    <string name="prefs_theme_system">system default</string>
+    <string name="prefs_theme_light">light theme</string>
+    <string name="prefs_theme_dark">dark theme</string>
+    <string name="prefs_theme_val_system" translatable="false">system</string>
+    <string name="prefs_theme_val_light" translatable="false">light</string>
+    <string name="prefs_theme_val_dark" translatable="false">dark</string>
+
     <string name="prefs_data_title">Metadata</string>
     <string name="prefs_use_proofmode_title">Enable ProofMode</string>
     <string name="prefs_use_proofmode_summary">Capture extra metadata and notarize all media</string>
@@ -312,6 +322,7 @@
     <string name="description_dropbox">Securely access the commercial cloud</string>
     <string name="metadata">Metadata</string>
     <string name="networking">Networking</string>
+    <string name="user_interface">User Interface</string>
     <string name="pref_nextcloud_title">Enable NextCloud Chunking</string>
     <string name="pref_nextcloud_subject">If you are connecting to a NextCloud server, enable more resilient uploads</string>
 

--- a/app/src/main/res/xml/app_prefs_user_interface.xml
+++ b/app/src/main/res/xml/app_prefs_user_interface.xml
@@ -1,0 +1,15 @@
+<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <androidx.preference.PreferenceCategory android:title="@string/prefs_user_interface_title">
+
+        <androidx.preference.ListPreference
+            android:defaultValue="@string/prefs_theme_val_system"
+            android:entries="@array/ar_prefs_theme_labels"
+            android:entryValues="@array/ar_prefs_theme_val"
+            android:key="theme"
+            android:summary="@string/prefs_theme_summary"
+            android:title="@string/prefs_theme_title" />
+
+    </androidx.preference.PreferenceCategory>
+
+</androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Added these settings to help me test themes, and give users an option to override the system theme settings.

Here are a quick few screenshots of the added settings:

<img src="https://github.com/OpenArchive/Save-app-android/assets/674081/60abd221-04f2-4815-a30b-10d61c7ee81f" width="150" />
<img src="https://github.com/OpenArchive/Save-app-android/assets/674081/183c2df2-b88e-495e-bd21-4fb433a268dd" width="150" />
<img src="https://github.com/OpenArchive/Save-app-android/assets/674081/46480c3a-f5c6-49cc-8b37-64b4c8411de4" width="150" />
