### PR TITLE
Fixed the word Choice & Spelling Issues on General Settings Page

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,8 +144,8 @@
     <string name="prefs_nearby_title">Nearby</string>
 
     <string name="prefs_user_interface_title">Presentation</string>
-    <string name="prefs_theme_title">Style</string>
-    <string name="prefs_theme_summary">Change how Safe looks.</string>
+    <string name="prefs_theme_title">Theme</string>
+    <string name="prefs_theme_summary">Change Saves theme to light/dark.</string>
     <string name="prefs_theme_system">System Controlled</string>
     <string name="prefs_theme_light">Light</string>
     <string name="prefs_theme_dark">Dark</string>


### PR DESCRIPTION
## Description
Fixed the typo of the following.
1. For General Settings / "Presentation"
    Rename "Style" to "Theme"

2. Under "Style"
    Please change "Safe" to "Save" and have the text read: Change Save's theme to 
    light/dark
    
## Testing Instructions

1. Go to Settings
2. Go to General
3. See the Changes below presentation



## Screenshots or Screencast 

![image](https://github.com/OpenArchive/Save-app-android/assets/60827173/16c64c7b-76c5-401e-b013-82a60dbe4ece)
