### PR TITLE
Rename "space" to "server" everywhere the user sees that word

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -237,8 +237,8 @@
     <string name="oa_subtitle_3">Capture notes, location and people with each piece of media</string>
     <string name="oa_title_4">Ensure Authenticity</string>
     <string name="oa_subtitle_4">Includes your credentials while \"Save\" adds extra metadata to help with chain of custody and verification workflows</string>
-    <string name="connect_your_space">To get started, connect to a space to store your media.</string>
-    <string name="set_up_where_you_want_your_media_to_be_stored">In settings, you can add another storage space and connect to multiple servers</string>
+    <string name="connect_your_space">To get started, connect to a derver to store your media.</string>
+    <string name="set_up_where_you_want_your_media_to_be_stored">In settings, you can add another storage server and connect to multiple servers</string>
     <string name="send_directly_to_a_private_server">Send to a webdav server</string>
     <string name="upload_to_the_internet_archive">Upload to the IA</string>
     <string name="save_connects_to_webdav_compatible_servers_only_such_as_nextcloud_and_owncloud"><b><i>Save</i></b> only connects to WebDAV-compatible servers, e.g Nextcloud and ownCloud.</string>
@@ -316,7 +316,7 @@
     <string name="batch_waiting_for_upload">Waiting for upload…</string>
     <string name="batch_uploading_now">Uploading now…</string>
     <string name="login_activity_logging_message">Logging in…</string>
-    <string name="login_you_have_already_space">You\'ve already got a space with these credentials</string>
+    <string name="login_you_have_already_space">You\'ve already got a server with these credentials</string>
     <string name="tor_connection_exception">Unable to connect to Orbot/Tor.</string>
     <string name="tor_connection_timeout">Unable to connect to Orbot/Tor: TIMEOUT</string>
     <string name="tor_connection_invalid">Unable to connect to Orbot/Tor: INVALID</string>

--- a/local.properties
+++ b/local.properties
@@ -4,5 +4,6 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-#Tue May 24 11:05:54 EDT 2022
+#Thu Oct 12 12:21:17 IST 2023
 dropbox_key="gd5sputfo57s1l1"
+sdk.dir=C\:\\Users\\dell\\AppData\\Local\\Android\\Sdk


### PR DESCRIPTION
Linked Issue #504 

## Description
Rename all the places where space was used and replaced it with server.
    
## Testing Instructions





## Screenshots or Screencast 


![Screenshot_20231012_144405](https://github.com/OpenArchive/Save-app-android/assets/60827173/b7f040a2-61e2-415e-8559-e3a2ab57111a)
