### PR TITLE
fix(onboarding): arrow graphic is hidden on small width devices

### DIFF
--- a/app/src/main/res/layout-sw480dp/activity_onboarding23.xml
+++ b/app/src/main/res/layout-sw480dp/activity_onboarding23.xml
@@ -43,10 +43,9 @@
             android:id="@+id/get_started"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center"
             android:clickable="true"
             android:focusable="true"
-            android:orientation="vertical"
+            android:orientation="horizontal"
             android:paddingLeft="20dp"
             android:paddingRight="20dp"
             android:paddingBottom="10dp">
@@ -62,9 +61,9 @@
             <ImageView
                 android:id="@+id/arrow"
                 android:layout_width="24dp"
-                android:layout_height="wrap_content"
+                android:layout_height="match_parent"
                 android:adjustViewBounds="true"
-                android:paddingTop="8dp"
+                android:paddingStart="8dp"
                 android:src="@drawable/onboarding23_arrow_right"
                 app:tint="@color/colorOnboarding23GetStarted" />
 


### PR DESCRIPTION
fixes issue #561.  the device reported is 74mm wide which is around 466dp. use a vertical orientation by default and anything greater than 466dp use a horizontal orientation.

tested on small and medium emulators.

Such a good use case for jetpack compose.