### PR TITLE
🧮 disable NetCipher (Tor) on Android 14+

### DIFF
--- a/app/src/main/java/net/opendasharchive/openarchive/SaveApp.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/SaveApp.kt
@@ -1,6 +1,10 @@
 package net.opendasharchive.openarchive
 
+import android.app.AlertDialog
 import android.content.Context
+import android.content.DialogInterface
+import android.os.Build
+import androidx.appcompat.view.ContextThemeWrapper
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.imagepipeline.core.ImagePipelineConfig
 import com.facebook.imagepipeline.decoder.SimpleProgressiveJpegConfig
@@ -42,13 +46,17 @@ class SaveApp : SugarApp() {
     }
 
     private fun initNetCipher() {
-        Timber.d( "Initializing NetCipher client")
-        val oh = OrbotHelper.get(this)
+        // NetCipher initialization is broken on Android 14 and above
+        // So we're not offering Tor integration on these Android versions.
+        // https://github.com/OpenArchive/Save-app-android/issues/534
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.TIRAMISU) {
+            val oh = OrbotHelper.get(this)
 
-        if (BuildConfig.DEBUG) {
-            oh.skipOrbotValidation()
+            if (BuildConfig.DEBUG) {
+                oh.skipOrbotValidation()
+            }
+
+            oh.init()
         }
-
-        oh.init()
     }
 }

--- a/app/src/main/java/net/opendasharchive/openarchive/features/main/MainActivity.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/main/MainActivity.kt
@@ -2,6 +2,8 @@ package net.opendasharchive.openarchive.features.main
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.app.AlertDialog
+import android.content.DialogInterface
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
@@ -11,6 +13,7 @@ import android.view.MenuItem
 import android.widget.ProgressBar
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.view.ContextThemeWrapper
 import androidx.appcompat.widget.TooltipCompat
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -53,6 +56,7 @@ import net.opendasharchive.openarchive.util.extensions.scaled
 import net.opendasharchive.openarchive.util.extensions.setDrawable
 import net.opendasharchive.openarchive.util.extensions.show
 import net.opendasharchive.openarchive.util.extensions.toggle
+import timber.log.Timber
 import java.text.NumberFormat
 
 class MainActivity : BaseActivity(), FolderAdapterListener, SpaceAdapterListener {
@@ -203,6 +207,20 @@ class MainActivity : BaseActivity(), FolderAdapterListener, SpaceAdapterListener
                 this
             ) { _, _ ->
                 addClicked(typeFiles = true)
+            }
+        }
+
+        // Prompt users when that Saves built in Tor support is not available on Android 14+.
+        // https://github.com/OpenArchive/Save-app-android/issues/534
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            if (Prefs.useTor) {
+                Timber.d("NetCipher incompatible, prompting user to deactivate TOR.")
+                AlertDialog.Builder(ContextThemeWrapper(this, R.style.AlertDialogTheme))
+                    .setMessage(getString(R.string.tor_not_available_dialog))
+                    .setPositiveButton(getString(R.string.deactivate_tor)) { _: DialogInterface, _: Int -> Prefs.useTor = false }
+                    .setCancelable(false)
+                    .create()
+                    .show()
             }
         }
     }

--- a/app/src/main/java/net/opendasharchive/openarchive/features/settings/GeneralSettingsActivity.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/settings/GeneralSettingsActivity.kt
@@ -1,6 +1,7 @@
 package net.opendasharchive.openarchive.features.settings
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.preference.Preference
@@ -80,6 +81,14 @@ class GeneralSettingsActivity: BaseActivity() {
                 }
 
                 true
+            }
+
+            // Hide Tor option on android 14+ because NetCipher doesn't work on this API level
+            // https://github.com/OpenArchive/Save-app-android/issues/534
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                findPreference<Preference>(Prefs.USE_TOR)?.let {
+                     it.isVisible = false
+                }
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -283,5 +283,7 @@
     <string name="gdrive_disclaimer_2" formatted="true">%1$s\'s APIs allow you to send media to your %2$s via %3$s. %3$s, however, cannot see or access anything on your %2$s, which you didn\'t create with %3$s in the first place.</string>
     <string name="gdrive_auth_insufficient_permissions" formatted="true">%1$s cannot work properly if you don\'t allow it to write to your %2$s. Please try the authorization again and make sure to grant all the access permissions listed.</string>
     <string name="new_user">new user</string>
+    <string name="tor_not_available_dialog">Tor integration is not available on Android 14 and above. You can use Orbot VPN for routing Save through the Tor network.</string>
+    <string name="deactivate_tor">Deactivate Tor</string>
 
 </resources>


### PR DESCRIPTION
I think this should be enough close #534. Especially since there are/were plans to replace NetCipher with TorServices #258 