### PR TITLE
fix(gradle)!: define custom properties in user home directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,52 +27,53 @@ workflows:
                 - /feature\/.*/
                 - /bug\/.*/
 
-setup_steps: &setup
-  steps:
-    - checkout
-    - restore_cache:
-        key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
-    - run:
-        name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
-        command: sudo chmod +x ./gradlew
-    - run:
-        name: Create user properties
-        command: mkdir $HOME/.gradle && touch $HOME/.gradle/gradle.properties
-    - run:
-        name: Add user properties
-        command: |
-          if [ ! -f $HOME/.gradle/gradle.properties ]; then
-            echo "oaDropboxKey=\"${OA_DROPBOX_KEY:-foo}\"" >> $HOME/.gradle/gradle.properties
-          else
-            cat $HOME/.gradle/gradle.properties
-          fi
-save_steps: &save
-  steps:
-    - save_cache:
-        paths:
-          - ~/.gradle
-        key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+commands:
+  setup:
+    steps:
+      - checkout
+      - restore_cache:
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+      - run:
+          name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
+          command: sudo chmod +x ./gradlew
+      - run:
+          name: Create user properties
+          command: mkdir $HOME/.gradle && touch $HOME/.gradle/gradle.properties
+      - run:
+          name: Add user properties
+          command: |
+            if [ ! -f $HOME/.gradle/gradle.properties ]; then
+              echo "oaDropboxKey=\"${OA_DROPBOX_KEY:-foo}\"" >> $HOME/.gradle/gradle.properties
+            else
+              cat $HOME/.gradle/gradle.properties
+            fi
+  save:
+    steps:
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
 
 jobs:
   test:
     executor: android
-    <<: *setup
     steps:
+      - setup
       - run:
           name: Run Tests
           command: ./gradlew test
       - store_test_results: # for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
           path: app/build/test-results
-    <<: *save
+      - save
 
   lint:
     executor: android
-    <<: *setup
     steps:
+      - setup
       - run:
           name: Run Tests
           command: ./gradlew lint
       - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
           path: app/build/reports
           destination: reports
-    <<: *save
+      - save

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,34 +1,79 @@
 version: 2
-jobs:
-  build:
+
+workflows:
+  build-lint-test:
+    jobs:
+      - setup
+      - lint:
+          requires:
+            - setup
+          filters:
+            branches:
+              only:
+                - development
+                - /feature\/.*/
+                - /bug\/.*/
+      - test:
+          requires:
+            - setup
+          filters:
+            branches:
+              only:
+                - development
+                - /feature\/.*/
+                - /bug\/.*/
+
+executors:
+  android:
     working_directory: ~/code
     docker:
       - image: cimg/android:2024.01
     environment:
       JVM_OPTS: -Xmx3200m
+
+jobs:
+  setup:
+    executor: android
     steps:
       - checkout
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
-      #      - run:
-      #         name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
-      #         command: sudo chmod +x ./gradlew
       - run:
-          name: Create local.properties
-          command: touch local.properties
+          name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
+          command: sudo chmod +x ./gradlew
       - run:
-          name: Add dummy api Key
-          command: echo "dropbox_key=\"foo\"" >> local.properties
+          name: Create user properties
+          command: mkdir $HOME/.gradle && touch $HOME/.gradle/gradle.properties
+      - run:
+          name: Add user properties
+          command: |
+            if [ ! -f $HOME/.gradle/gradle.properties ]; then
+              echo "oaDropboxKey=\"${OA_DROPBOX_KEY:-foo}\"" >> $HOME/.gradle/gradle.properties
+            else
+              cat $HOME/.gradle/gradle.properties
+            fi
       - save_cache:
           paths:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+
+  test:
+    executor: android
+    steps:
       - run:
           name: Run Tests
-          command: ./gradlew lint test
+          command: ./gradlew test
+      - store_test_results: # for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+          path: app/build/test-results
+
+  lint:
+    executor: android
+    environment:
+      JVM_OPTS: -Xmx3200m
+    steps:
+      - run:
+          name: Run Tests
+          command: ./gradlew lint
       - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
           path: app/build/reports
           destination: reports
-      - store_test_results: # for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
-          path: app/build/test-results
-      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,50 +28,51 @@ workflows:
                 - /bug\/.*/
 
 setup_steps: &setup
-  - checkout
-  - restore_cache:
-      key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
-  - run:
-      name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
-      command: sudo chmod +x ./gradlew
-  - run:
-      name: Create user properties
-      command: mkdir $HOME/.gradle && touch $HOME/.gradle/gradle.properties
-  - run:
-      name: Add user properties
-      command: |
-        if [ ! -f $HOME/.gradle/gradle.properties ]; then
-          echo "oaDropboxKey=\"${OA_DROPBOX_KEY:-foo}\"" >> $HOME/.gradle/gradle.properties
-        else
-          cat $HOME/.gradle/gradle.properties
-        fi
-
+  steps:
+    - checkout
+    - restore_cache:
+        key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+    - run:
+        name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
+        command: sudo chmod +x ./gradlew
+    - run:
+        name: Create user properties
+        command: mkdir $HOME/.gradle && touch $HOME/.gradle/gradle.properties
+    - run:
+        name: Add user properties
+        command: |
+          if [ ! -f $HOME/.gradle/gradle.properties ]; then
+            echo "oaDropboxKey=\"${OA_DROPBOX_KEY:-foo}\"" >> $HOME/.gradle/gradle.properties
+          else
+            cat $HOME/.gradle/gradle.properties
+          fi
 save_steps: &save
-  - save_cache:
-      paths:
-        - ~/.gradle
-      key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+  steps:
+    - save_cache:
+        paths:
+          - ~/.gradle
+        key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
 
 jobs:
   test:
     executor: android
+    <<: *setup
     steps:
-      - *setup
       - run:
           name: Run Tests
           command: ./gradlew test
-      - *save
       - store_test_results: # for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
           path: app/build/test-results
+    <<: *save
 
   lint:
     executor: android
+    <<: *setup
     steps:
-      - *setup
       - run:
           name: Run Tests
           command: ./gradlew lint
-      - *save
       - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
           path: app/build/reports
           destination: reports
+    <<: *save

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ executors:
     working_directory: ~/code
     docker:
       - image: cimg/android:2024.01
+    resource_class: medium
     environment:
       JVM_OPTS: -Xmx3200m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2
 
 workflows:
+  version: 2
   build-lint-test:
     jobs:
       - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,18 @@
-version: 2
+version: 2.1
+
+executors:
+  android:
+    working_directory: ~/save-app
+    docker:
+      - image: cimg/android:2024.01
+    environment:
+      JVM_OPTS: -Xmx3200m
 
 workflows:
-  version: 2
+  version: 2.1
   build-lint-test:
     jobs:
-      - setup
       - lint:
-          requires:
-            - setup
           filters:
             branches:
               only:
@@ -15,8 +20,6 @@ workflows:
                 - /feature\/.*/
                 - /bug\/.*/
       - test:
-          requires:
-            - setup
           filters:
             branches:
               only:
@@ -24,58 +27,51 @@ workflows:
                 - /feature\/.*/
                 - /bug\/.*/
 
-executors:
-  android:
-    working_directory: ~/code
-    docker:
-      - image: cimg/android:2024.01
-    resource_class: medium
-    environment:
-      JVM_OPTS: -Xmx3200m
+setup_steps: &setup
+  - checkout
+  - restore_cache:
+      key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+  - run:
+      name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
+      command: sudo chmod +x ./gradlew
+  - run:
+      name: Create user properties
+      command: mkdir $HOME/.gradle && touch $HOME/.gradle/gradle.properties
+  - run:
+      name: Add user properties
+      command: |
+        if [ ! -f $HOME/.gradle/gradle.properties ]; then
+          echo "oaDropboxKey=\"${OA_DROPBOX_KEY:-foo}\"" >> $HOME/.gradle/gradle.properties
+        else
+          cat $HOME/.gradle/gradle.properties
+        fi
+
+save_steps: &save
+  - save_cache:
+      paths:
+        - ~/.gradle
+      key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
 
 jobs:
-  setup:
-    executor: android
-    steps:
-      - checkout
-      - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
-      - run:
-          name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
-          command: sudo chmod +x ./gradlew
-      - run:
-          name: Create user properties
-          command: mkdir $HOME/.gradle && touch $HOME/.gradle/gradle.properties
-      - run:
-          name: Add user properties
-          command: |
-            if [ ! -f $HOME/.gradle/gradle.properties ]; then
-              echo "oaDropboxKey=\"${OA_DROPBOX_KEY:-foo}\"" >> $HOME/.gradle/gradle.properties
-            else
-              cat $HOME/.gradle/gradle.properties
-            fi
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
-
   test:
     executor: android
     steps:
+      - *setup
       - run:
           name: Run Tests
           command: ./gradlew test
+      - *save
       - store_test_results: # for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
           path: app/build/test-results
 
   lint:
     executor: android
-    environment:
-      JVM_OPTS: -Xmx3200m
     steps:
+      - *setup
       - run:
           name: Run Tests
           command: ./gradlew lint
+      - *save
       - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
           path: app/build/reports
           destination: reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,15 +37,14 @@ commands:
           name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
           command: sudo chmod +x ./gradlew
       - run:
-          name: Create user properties
-          command: mkdir $HOME/.gradle && touch $HOME/.gradle/gradle.properties
+          name: Create user properties folder
+          command: mkdir $HOME/.gradle
       - run:
           name: Add user properties
           command: |
-            if [ ! -f $HOME/.gradle/gradle.properties ]; then
+            if [ ! grep oaDropboxKey $HOME/.gradle/gradle.properties ]; then
+              echo "Setting user properties"
               echo "oaDropboxKey=\"${OA_DROPBOX_KEY:-foo}\"" >> $HOME/.gradle/gradle.properties
-            else
-              cat $HOME/.gradle/gradle.properties
             fi
   save:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
       - run:
           name: Add user properties
           command: |
-            if [ ! grep oaDropboxKey $HOME/.gradle/gradle.properties ]; then
+            if [ ! `grep "oaDropboxKey" "$HOME/.gradle/gradle.properties"` ]; then
               echo "Setting user properties"
               echo "oaDropboxKey=\"${OA_DROPBOX_KEY:-foo}\"" >> $HOME/.gradle/gradle.properties
             fi
@@ -56,6 +56,7 @@ commands:
 jobs:
   test:
     executor: android
+    parallelism: 3
     steps:
       - setup
       - run:
@@ -67,6 +68,7 @@ jobs:
 
   lint:
     executor: android
+    parallelism: 3
     steps:
       - setup
       - run:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,12 +2,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'org.jetbrains.kotlin.android'
 
-def getDropboxKey() {
-    Properties properties = new Properties()
-    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-    return properties.getProperty("dropbox_key")
-}
-
 android {
     compileOptions {
         sourceCompatibility 1.8
@@ -34,15 +28,15 @@ android {
     flavorDimensions += "free"
     buildTypes {
         debug {
-            buildConfigField "String", "dropbox_key", getDropboxKey()
-            resValue 'string', "dropbox_key", getDropboxKey()
+            // Define OpenArchive variables in $HOME/.gradle/gradle.properties
+            buildConfigField "String", "dropbox_key", oaDropboxKey
         }
 
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            buildConfigField "String", "dropbox_key", getDropboxKey()
-            resValue 'string', "dropbox_key", getDropboxKey()
+            // Define OpenArchive variables in $HOME/.gradle/gradle.properties
+            buildConfigField "String", "dropbox_key", oaDropboxKey
         }
     }
     packagingOptions {


### PR DESCRIPTION
also using resource strings for properties is very bad from a security disassembly perspective.

The reason is less boiler plate and because local.properties is often auto-generated and mistakenly committed.

Properties can be prefixed with 'oa' to avoid conflicts with other projects

Example: in $HOME/.gradle/gradle.properties

oaDropboxKey="someKey"