### PR TITLE
fix(main): ensure settings in adapter is always in line with button order

### DIFF
--- a/app/src/main/java/net/opendasharchive/openarchive/features/main/ProjectAdapter.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/main/ProjectAdapter.kt
@@ -19,7 +19,7 @@ class ProjectAdapter(fragmentManager: FragmentManager, lifecycle: Lifecycle) :
     }
 
     val settingsIndex: Int
-        get() = projects.size
+        get() = max(1, projects.size)
 
     fun updateData(projects: List<Project>) {
         this.projects = projects


### PR DESCRIPTION
previously the settings page would show up as the media page