### PR TITLE
Internet Archive uploads

### DIFF
--- a/app/src/main/java/net/opendasharchive/openarchive/db/MediaAdapter.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/db/MediaAdapter.kt
@@ -76,11 +76,14 @@ class MediaAdapter(
                                     it, it.getString(R.string.upload_unsuccessful_description),
                                     R.string.upload_unsuccessful, R.drawable.ic_error, listOf(
                                         AlertHelper.positiveButton(R.string.retry) { _, _ ->
-                                            media[pos].sStatus = Media.Status.Queued
-                                            media[pos].statusMessage = ""
-                                            media[pos].save()
 
-                                            updateItem(media[pos].id)
+                                            media[pos].apply {
+                                                sStatus = Media.Status.Queued
+                                                statusMessage = ""
+                                                save()
+
+                                                BroadcastManager.postChange(it, collectionId, id)
+                                            }
 
                                             UploadService.startUploadService(it)
                                         },

--- a/app/src/main/java/net/opendasharchive/openarchive/db/MediaAdapter.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/db/MediaAdapter.kt
@@ -139,14 +139,16 @@ class MediaAdapter(
         holder.handle?.toggle(isEditMode)
     }
 
-    fun updateItem(mediaId: Long): Boolean {
+    fun updateItem(mediaId: Long, progress: Long): Boolean {
         val idx = media.indexOfFirst { it.id == mediaId }
         if (idx < 0) return false
 
-        val item = Media.get(mediaId) ?: return false
-
-        media[idx] = item
-
+        if (progress >= 0) {
+            media[idx].progress = progress
+        } else {
+            val item = Media.get(mediaId) ?: return false
+            media[idx] = item
+        }
         notifyItemChanged(idx)
 
         return true

--- a/app/src/main/java/net/opendasharchive/openarchive/db/MediaViewHolder.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/db/MediaViewHolder.kt
@@ -28,6 +28,7 @@ import net.opendasharchive.openarchive.fragments.VideoRequestHandler
 import net.opendasharchive.openarchive.util.extensions.hide
 import net.opendasharchive.openarchive.util.extensions.show
 import timber.log.Timber
+import java.io.InputStream
 import kotlin.math.roundToInt
 
 abstract class MediaViewHolder(protected val binding: ViewBinding): RecyclerView.ViewHolder(binding.root) {
@@ -303,18 +304,19 @@ abstract class MediaViewHolder(protected val binding: ViewBinding): RecyclerView
                 fileInfo?.text = Formatter.formatShortFileSize(mContext, file.length())
             } else {
                 if (media.contentLength == -1L) {
+                    var iStream: InputStream? = null
                     try {
-                        val iStream = mContext.contentResolver.openInputStream(media.fileUri)
+                        iStream = mContext.contentResolver.openInputStream(media.fileUri)
 
                         if (iStream != null) {
                             media.contentLength = iStream.available().toLong()
                             media.save()
-
-                            iStream.close()
                         }
                     }
                     catch (e: Throwable) {
                         Timber.e(e)
+                    } finally {
+                        iStream?.close()
                     }
                 }
 

--- a/app/src/main/java/net/opendasharchive/openarchive/features/main/MainMediaFragment.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/main/MainMediaFragment.kt
@@ -56,7 +56,7 @@ class MainMediaFragment : Fragment() {
             when (action) {
                 BroadcastManager.Action.Change -> {
                     handler.post {
-                        updateItem(action.collectionId, action.mediaId)
+                        updateItem(action.collectionId, action.mediaId, action.progress)
                     }
                 }
 
@@ -121,9 +121,9 @@ class MainMediaFragment : Fragment() {
         refresh()
     }
 
-    fun updateItem(collectionId: Long, mediaId: Long) {
+    fun updateItem(collectionId: Long, mediaId: Long, progress: Long) {
         mAdapters[collectionId]?.apply {
-            updateItem(mediaId)
+            updateItem(mediaId, progress)
              mCollections[collectionId]?.let { collection ->
                  mSection[collectionId]?.setHeader(collection, media)
              }

--- a/app/src/main/java/net/opendasharchive/openarchive/features/main/SectionViewHolder.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/main/SectionViewHolder.kt
@@ -37,7 +37,7 @@ data class SectionViewHolder(
         collection: Collection,
         media: List<Media>
     ) {
-        if (media.firstOrNull { it.isUploading } != null)
+        if (media.any { it.isUploading })
         {
             timestamp.setText(R.string.uploading)
 

--- a/app/src/main/java/net/opendasharchive/openarchive/services/Conduit.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/Conduit.kt
@@ -90,15 +90,15 @@ abstract class Conduit(
      * result is a site specific unique id that we can use to fetch the data,
      * build an embed tag, etc. for some sites this might be a URL
      */
-    fun jobSucceeded() {
-        mMedia.progress = 100
+     fun jobSucceeded() {
+        mMedia.progress = mMedia.contentLength
         mMedia.sStatus = Media.Status.Uploaded
         mMedia.save()
 
-        BroadcastManager.postChange(mContext, mMedia.id)
+        BroadcastManager.postChange(mContext, mMedia.collectionId, mMedia.id)
     }
 
-    fun jobFailed(exception: Throwable) {
+     fun jobFailed(exception: Throwable) {
         // If an upload was cancelled, ignore the error.
         if (mCancelled) return
 
@@ -109,14 +109,14 @@ abstract class Conduit(
 
         Timber.d(exception)
 
-        BroadcastManager.postChange(mContext, mMedia.id)
+        BroadcastManager.postChange(mContext, mMedia.collectionId, mMedia.id)
     }
 
     // track when the last progress broadcast was sent, timestamp
     // we use this to limit the rate of sending out these broadcasts
     private var lastProgressBroadcast = 0L
 
-    fun jobProgress(uploadedBytes: Long) {
+     fun jobProgress(uploadedBytes: Long) {
         // making sure we're not writing to the database more often than (1000/150=)~7 times a second.
         // jobProgress is getting called up to several hundred times a second.
         if (System.currentTimeMillis() > lastProgressBroadcast + 150) {
@@ -125,7 +125,7 @@ abstract class Conduit(
             mMedia.progress = uploadedBytes
             mMedia.save()
 
-            BroadcastManager.postChange(mContext, mMedia.id)
+            BroadcastManager.postChange(mContext, mMedia.collectionId, mMedia.id)
         }
     }
 

--- a/app/src/main/java/net/opendasharchive/openarchive/services/Conduit.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/Conduit.kt
@@ -112,22 +112,11 @@ abstract class Conduit(
         BroadcastManager.postChange(mContext, mMedia.collectionId, mMedia.id)
     }
 
-    // track when the last progress broadcast was sent, timestamp
-    // we use this to limit the rate of sending out these broadcasts
-    private var lastProgressBroadcast = 0L
-
      fun jobProgress(uploadedBytes: Long) {
-        // making sure we're not writing to the database more often than (1000/150=)~7 times a second.
-        // jobProgress is getting called up to several hundred times a second.
-        if (System.currentTimeMillis() > lastProgressBroadcast + 150) {
-            lastProgressBroadcast = System.currentTimeMillis()
+         mMedia.progress = uploadedBytes
 
-            mMedia.progress = uploadedBytes
-            mMedia.save()
-
-            BroadcastManager.postChange(mContext, mMedia.collectionId, mMedia.id)
-        }
-    }
+         BroadcastManager.postProgress(mContext, mMedia.collectionId, mMedia.id, uploadedBytes)
+     }
 
     /**
      * workaround to deal with some quirks in our data model?

--- a/app/src/main/java/net/opendasharchive/openarchive/services/SaveClient.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/SaveClient.kt
@@ -35,9 +35,9 @@ class SaveClient(context: Context) : StrongBuilderBase<SaveClient, OkHttpClient>
 
         okBuilder = OkHttpClient.Builder()
             .addInterceptor(cacheInterceptor)
-            .connectTimeout(20L, TimeUnit.SECONDS)
-            .writeTimeout(20L, TimeUnit.SECONDS)
-            .readTimeout(20L, TimeUnit.SECONDS)
+            .connectTimeout(40L, TimeUnit.SECONDS)
+            .writeTimeout(40L, TimeUnit.SECONDS)
+            .readTimeout(40L, TimeUnit.SECONDS)
             .retryOnConnectionFailure(false)
             .protocols(arrayListOf(Protocol.HTTP_1_1))
     }

--- a/app/src/main/java/net/opendasharchive/openarchive/services/internetarchive/RequestBodyUtil.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/internetarchive/RequestBodyUtil.kt
@@ -12,19 +12,27 @@ import okio.Source
 import timber.log.Timber
 import java.io.*
 
+fun createListener(cancellable: () -> Boolean, onProgress: (Long) -> Unit = {}, onComplete: () -> Unit = {}) = object : RequestListener {
+    override fun transferred(bytes: Long) = onProgress(bytes)
+
+    override fun continueUpload() =  cancellable()
+
+    override fun transferComplete() = Unit
+}
+
 /**
  * Created by n8fr8 on 12/29/17.
  */
 object RequestBodyUtil {
-    fun create(mediaType: MediaType?, inputStream: InputStream): RequestBody {
+
+    fun create(mediaType: MediaType?, inputStream: InputStream, contentLength: Long? = null,
+               listener: RequestListener?): RequestBody {
         return object : RequestBody() {
-            override fun contentType(): MediaType? {
-                return mediaType
-            }
+            override fun contentType() = mediaType
 
             override fun contentLength(): Long {
                 return try {
-                    inputStream.available().toLong()
+                    contentLength ?: inputStream.available().toLong()
                 } catch (e: IOException) {
                     Timber.i("BodyRequestUtil couldn't get contentLength, returning 0 instead", e)
                     0
@@ -36,7 +44,7 @@ object RequestBodyUtil {
                 var source: Source? = null
                 try {
                     source = inputStream.source()
-                    sink.writeAll(source)
+                    sink.writeAll(source, listener)
                 } finally {
                     source!!.closeQuietly()
                 }
@@ -66,38 +74,39 @@ object RequestBodyUtil {
                 }
             }
 
-            override fun contentType(): MediaType? {
-                return mediaType
-            }
+            override fun contentType() = mediaType
 
-            override fun contentLength(): Long {
-                return contentLength
-            }
+            override fun contentLength() = contentLength
 
             @Synchronized
             @Throws(IOException::class)
             override fun writeTo(sink: BufferedSink) {
                 init()
-                val source = inputStream!!.source()
-                if (mListener == null) {
-                    sink.writeAll(source)
-                } else {
-                    try {
-                        var total: Long = 0
-                        var read: Long
-                        while (source.read(sink.buffer, SEGMENT_SIZE.toLong()).also {
-                                read = it
-                            } != -1L && mListener != null && mListener!!.continueUpload()) {
-                            total += read
-                            if (mListener != null) mListener!!.transferred(total)
-                            sink.flush()
-                        }
-                        mListener!!.transferComplete()
-                    } finally {
-                        source.closeQuietly()
-                    }
+                var source: Source? = null
+                try {
+                    source = inputStream!!.source()
+                    sink.writeAll(source, listener)
+                } finally {
+                    source?.closeQuietly()
                 }
             }
+        }
+    }
+
+    fun BufferedSink.writeAll(source: Source, listener: RequestListener?) {
+        if (listener == null) {
+            writeAll(source)
+        } else {
+            var total: Long = 0
+            var read: Long
+            while (source.read(buffer, SEGMENT_SIZE.toLong()).also {
+                    read = it
+                } != -1L && listener.continueUpload()) {
+                total += read
+                listener.transferred(total)
+                flush()
+            }
+            listener.transferComplete()
         }
     }
 
@@ -112,13 +121,9 @@ object RequestBodyUtil {
                 }
             }
 
-            override fun contentType(): MediaType? {
-                return mediaType
-            }
+            override fun contentType() = mediaType
 
-            override fun contentLength(): Long {
-                return fileSource.length()
-            }
+            override fun contentLength() = fileSource.length()
 
             @Synchronized
             @Throws(IOException::class)

--- a/app/src/main/java/net/opendasharchive/openarchive/upload/BroadcastManager.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/upload/BroadcastManager.kt
@@ -8,18 +8,20 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager
 
 object BroadcastManager {
 
-    enum class Action(val id: String, var mediaId: Long = -1) {
+    enum class Action(val id: String, var collectionId: Long = -1, var mediaId: Long = -1) {
         Change("media_change_intent"),
         Delete("media_delete_intent")
     }
 
     private const val MEDIA_ID = "media_id"
+    private const val COLLECTION_ID = "collection_id"
 
-    fun postChange(context: Context, mediaId: Long) {
+    fun postChange(context: Context, collectionId: Long, mediaId: Long) {
         val i = Intent(Action.Change.id)
         i.putExtra(MEDIA_ID, mediaId)
+        i.putExtra(COLLECTION_ID, collectionId)
 
-        LocalBroadcastManager.getInstance(context).sendBroadcast(i)
+        LocalBroadcastManager.getInstance(context).sendBroadcastSync(i)
     }
 
     fun postDelete(context: Context, mediaId: Long) {
@@ -32,6 +34,7 @@ object BroadcastManager {
     fun getAction(intent: Intent): Action? {
         val action = Action.values().firstOrNull { it.id == intent.action }
         action?.mediaId = intent.getLongExtra(MEDIA_ID, -1)
+        action?.collectionId = intent.getLongExtra(COLLECTION_ID, -1)
 
         return action
     }

--- a/app/src/main/java/net/opendasharchive/openarchive/upload/BroadcastManager.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/upload/BroadcastManager.kt
@@ -8,18 +8,28 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager
 
 object BroadcastManager {
 
-    enum class Action(val id: String, var collectionId: Long = -1, var mediaId: Long = -1) {
+    enum class Action(val id: String, var collectionId: Long = -1, var mediaId: Long = -1, var progress: Long = -1) {
         Change("media_change_intent"),
         Delete("media_delete_intent")
     }
 
     private const val MEDIA_ID = "media_id"
     private const val COLLECTION_ID = "collection_id"
+    private const val MEDIA_PROGRESS = "media_progress"
 
     fun postChange(context: Context, collectionId: Long, mediaId: Long) {
         val i = Intent(Action.Change.id)
         i.putExtra(MEDIA_ID, mediaId)
         i.putExtra(COLLECTION_ID, collectionId)
+
+        LocalBroadcastManager.getInstance(context).sendBroadcastSync(i)
+    }
+
+    fun postProgress(context: Context, collectionId: Long, mediaId: Long, progress: Long) {
+        val i = Intent(Action.Change.id)
+        i.putExtra(MEDIA_ID, mediaId)
+        i.putExtra(COLLECTION_ID, collectionId)
+        i.putExtra(MEDIA_PROGRESS, progress)
 
         LocalBroadcastManager.getInstance(context).sendBroadcastSync(i)
     }
@@ -35,6 +45,7 @@ object BroadcastManager {
         val action = Action.values().firstOrNull { it.id == intent.action }
         action?.mediaId = intent.getLongExtra(MEDIA_ID, -1)
         action?.collectionId = intent.getLongExtra(COLLECTION_ID, -1)
+        action?.progress = intent.getLongExtra(MEDIA_PROGRESS, -1)
 
         return action
     }

--- a/app/src/main/java/net/opendasharchive/openarchive/upload/UploadManagerFragment.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/upload/UploadManagerFragment.kt
@@ -92,7 +92,7 @@ open class UploadManagerFragment : Fragment() {
     }
 
     open fun updateItem(mediaId: Long) {
-        mediaAdapter?.updateItem(mediaId)
+        mediaAdapter?.updateItem(mediaId, -1)
     }
 
     open fun removeItem(mediaId: Long) {

--- a/app/src/main/res/layout/rv_media_box.xml
+++ b/app/src/main/res/layout/rv_media_box.xml
@@ -85,7 +85,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="100%"
-        android:textSize="14sp"
+        android:textSize="12sp"
         android:visibility="gone"
         android:textColor="@color/colorPrimary"
         app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
only track progress on the content upload. metadata and proofs will upload asynchronously while still reporting errors

fixed metadata serialization to properly exclude fields

have broadcasts include progress information without db read/writes

Should solve #600 #599 