### PR TITLE
fix(upload manager): ensure main thread interactions from broadcast receiver

### DIFF
--- a/app/src/main/java/net/opendasharchive/openarchive/db/Project.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/db/Project.kt
@@ -37,7 +37,7 @@ data class Project(
         }
 
     val isUploading
-        get() = collections.firstOrNull { it.isUploading } != null
+        get() = collections.any { it.isUploading }
 
     val collections: List<Collection>
         get() = find(Collection::class.java, "project_id = ?", id.toString())

--- a/app/src/main/java/net/opendasharchive/openarchive/services/Conduit.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/Conduit.kt
@@ -49,6 +49,7 @@ abstract class Conduit(
 
     open fun cancel() {
         mCancelled = true
+        mMedia.save()
     }
 
 

--- a/app/src/main/java/net/opendasharchive/openarchive/upload/UploadManagerActivity.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/upload/UploadManagerActivity.kt
@@ -48,6 +48,8 @@ class UploadManagerActivity : BaseActivity() {
     }
 
     private val mMessageReceiver: BroadcastReceiver = object : BroadcastReceiver() {
+        private val handler = Handler(Looper.getMainLooper())
+
         override fun onReceive(context: Context, intent: Intent) {
             val action = BroadcastManager.getAction(intent)
             val mediaId = action?.mediaId ?: return
@@ -56,10 +58,10 @@ class UploadManagerActivity : BaseActivity() {
                 val media = Media.get(mediaId)
 
                 if (action == BroadcastManager.Action.Delete || media?.sStatus == Media.Status.Uploaded) {
-                    mFrag?.removeItem(mediaId)
+                    handler.post { mFrag?.removeItem(mediaId) }
                 }
                 else {
-                    mFrag?.updateItem(mediaId)
+                    handler.post { mFrag?.updateItem(mediaId) }
                 }
 
                 if (media?.sStatus == Media.Status.Error) {
@@ -70,7 +72,7 @@ class UploadManagerActivity : BaseActivity() {
                 }
             }
 
-            Handler(Looper.getMainLooper()).post {
+            handler.post {
                 updateTitle()
             }
         }

--- a/app/src/main/java/net/opendasharchive/openarchive/upload/UploadService.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/upload/UploadService.kt
@@ -18,6 +18,7 @@ import androidx.work.Configuration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import net.opendasharchive.openarchive.CleanInsightsManager
 import net.opendasharchive.openarchive.R
@@ -90,7 +91,7 @@ class UploadService : JobService() {
         mKeepUploading = false
         for (conduit in mConduits) conduit.cancel()
         mConduits.clear()
-
+        scope.cancel()
         return true
     }
 


### PR DESCRIPTION
save internet archive identifiers as the media server url (not a part of meta data)

ensure cancelled uploads are saved to prevent new file identifiers

ensure upload service coroutine scopes are cancelled on job cancel