### PR TITLE
Extracted dweb to separate activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -160,6 +160,14 @@
             android:windowSoftInputMode="adjustPan" />
 
         <activity
+            android:name=".services.snowbird.SnowbirdActivity"
+            android:exported="false"
+            android:label="@string/dweb_title"
+            android:taskAffinity=""
+            android:theme="@style/SaveAppTheme.NoActionBar"
+            android:windowSoftInputMode="adjustPan" />
+
+        <activity
             android:name=".features.onboarding.Onboarding23Activity"
             android:exported="false"
             android:noHistory="true"

--- a/app/src/main/java/net/opendasharchive/openarchive/features/core/BaseFragment.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/core/BaseFragment.kt
@@ -3,7 +3,6 @@ package net.opendasharchive.openarchive.features.core
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import net.opendasharchive.openarchive.analytics.api.AnalyticsManager
@@ -12,11 +11,12 @@ import net.opendasharchive.openarchive.core.logger.AppLogger
 import net.opendasharchive.openarchive.features.core.dialog.DialogStateManager
 import net.opendasharchive.openarchive.features.onboarding.SpaceSetupActivity
 import org.koin.android.ext.android.inject
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 import kotlin.getValue
 
 abstract class BaseFragment : Fragment(), ToolbarConfigurable {
 
-    protected val dialogManager: DialogStateManager by activityViewModels()
+    protected val dialogManager: DialogStateManager by activityViewModel()
 
     // Inject analytics dependencies
     protected val analyticsManager: AnalyticsManager by inject()

--- a/app/src/main/java/net/opendasharchive/openarchive/features/main/MainActivity.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/main/MainActivity.kt
@@ -17,7 +17,6 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.LinearLayout
 import android.widget.PopupWindow
-import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
@@ -70,6 +69,7 @@ import net.opendasharchive.openarchive.features.onboarding.Onboarding23Activity
 import net.opendasharchive.openarchive.features.onboarding.SpaceSetupActivity
 import net.opendasharchive.openarchive.features.onboarding.StartDestination
 import net.opendasharchive.openarchive.features.settings.passcode.AppConfig
+import net.opendasharchive.openarchive.services.snowbird.SnowbirdActivity
 import net.opendasharchive.openarchive.services.snowbird.SnowbirdBridge
 import net.opendasharchive.openarchive.services.snowbird.service.SnowbirdService
 import net.opendasharchive.openarchive.upload.UploadManagerFragment
@@ -1238,8 +1238,7 @@ class MainActivity : BaseActivity(), SpaceDrawerAdapterListener, FolderDrawerAda
     override fun onNavigateToDwebGroups() {
         collapseSpacesList()
         closeDrawer()
-        val intent = Intent(this, SpaceSetupActivity::class.java)
-        intent.putExtra("start_destination", StartDestination.DWEB_DASHBOARD.name)
+        val intent = Intent(this, SnowbirdActivity::class.java)
         startActivity(intent)
     }
 

--- a/app/src/main/java/net/opendasharchive/openarchive/features/onboarding/SpaceSetupActivity.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/onboarding/SpaceSetupActivity.kt
@@ -18,7 +18,6 @@ import net.opendasharchive.openarchive.features.settings.FoldersFragment
 enum class StartDestination {
     SPACE_TYPE,
     SPACE_LIST,
-    DWEB_DASHBOARD,
     ADD_FOLDER,
     ADD_NEW_FOLDER,
     ARCHIVED_FOLDER_LIST
@@ -102,9 +101,6 @@ class SpaceSetupActivity : BaseActivity() {
 
                 navController.setGraph(navGraph, bundle)
                 return // Early return to avoid setting graph again
-            }
-            StartDestination.DWEB_DASHBOARD -> {
-                navGraph.setStartDestination(R.id.snowbird_nav_graph)
             }
             else -> {
                 navGraph.setStartDestination(R.id.fragment_space_setup)

--- a/app/src/main/java/net/opendasharchive/openarchive/features/settings/SpaceSetupFragment.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/settings/SpaceSetupFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.content.Intent
 import androidx.fragment.compose.content
 import androidx.navigation.fragment.findNavController
 import net.opendasharchive.openarchive.R
@@ -13,6 +14,7 @@ import net.opendasharchive.openarchive.features.core.BaseFragment
 import net.opendasharchive.openarchive.features.settings.passcode.AppConfig
 import net.opendasharchive.openarchive.features.spaces.SpaceSetupScreen
 import org.koin.android.ext.android.inject
+import net.opendasharchive.openarchive.services.snowbird.SnowbirdActivity
 
 class SpaceSetupFragment : BaseFragment() {
 
@@ -39,9 +41,8 @@ class SpaceSetupFragment : BaseFragment() {
         // Show/hide Snowbird based on config
         val isDwebEnabled = appConfig.isDwebEnabled
         val onDwebClicked = {
-            val action =
-                    SpaceSetupFragmentDirections.actionFragmentSpaceSetupToFragmentSnowbird()
-                findNavController().navigate(action)
+            val intent = Intent(requireContext(), SnowbirdActivity::class.java)
+            startActivity(intent)
         }
 
         SaveAppTheme {

--- a/app/src/main/java/net/opendasharchive/openarchive/features/settings/SpaceSetupSuccessFragment.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/settings/SpaceSetupSuccessFragment.kt
@@ -3,21 +3,12 @@ package net.opendasharchive.openarchive.features.settings
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.os.bundleOf
 import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.MenuProvider
-import androidx.fragment.app.setFragmentResult
-import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import androidx.navigation.navOptions
 import net.opendasharchive.openarchive.R
 import net.opendasharchive.openarchive.databinding.FragmentSpaceSetupSuccessBinding
-import net.opendasharchive.openarchive.db.Space
 import net.opendasharchive.openarchive.features.core.BaseFragment
 import net.opendasharchive.openarchive.features.main.MainActivity
 import net.opendasharchive.openarchive.util.extensions.applyEdgeToEdgeInsets
@@ -50,60 +41,13 @@ class SpaceSetupSuccessFragment : BaseFragment() {
         }
 
         binding.btAuthenticate.setOnClickListener { _ ->
-            if (args.spaceType == Space.Type.RAVEN) {
-                val navController = findNavController()
-                // Navigate to Snowbird as the new root of this nav graph so Back exits to MainActivity
-                navController.navigate(
-                    R.id.action_fragment_space_setup_success_to_fragment_snowbird,
-                    null,
-                    navOptions {
-                        // Clear the entire Space Setup nav graph back stack
-                        popUpTo(R.id.space_setup_navigation) { inclusive = true }
-                        launchSingleTop = true
-                        restoreState = false
-                    }
-                )
-            } else {
                 val intent = Intent(requireActivity(), MainActivity::class.java)
                 intent.flags =
                     Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK // Clears backstack
                 startActivity(intent)
-            }
         }
 
         return binding.root
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        if (args.spaceType == Space.Type.RAVEN) {
-            // Add the menu provider
-            requireActivity().addMenuProvider(object : MenuProvider {
-                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
-                    menuInflater.inflate(R.menu.menu_space_setup_success, menu)
-                }
-
-                override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
-                    return when (menuItem.itemId) {
-                        R.id.action_share_group -> {
-                            if (args.dwebGroupKey != null) {
-                                val action =
-                                    SpaceSetupSuccessFragmentDirections.actionFragmentSpaceSetupSuccessToFragmentSnowbirdShareGroup(
-                                        dwebGroupKey = args.dwebGroupKey!!,
-                                        isSetupOngoing = true
-                                    )
-
-                                findNavController().navigate(action)
-                            }
-                            true
-                        }
-
-                        else -> false
-                    }
-                }
-            }, viewLifecycleOwner)
-        }
     }
 
     override fun getToolbarTitle() = getString(R.string.space_setup_success_title)

--- a/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/BaseSnowbirdFragment.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/BaseSnowbirdFragment.kt
@@ -5,25 +5,36 @@ import android.os.Bundle
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
 import net.opendasharchive.openarchive.R
+import net.opendasharchive.openarchive.analytics.api.AnalyticsManager
+import net.opendasharchive.openarchive.analytics.api.session.SessionTracker
+import net.opendasharchive.openarchive.core.logger.AppLogger
 import net.opendasharchive.openarchive.db.SnowbirdError
 import net.opendasharchive.openarchive.extensions.androidViewModel
 import net.opendasharchive.openarchive.features.core.BaseActivity
-import net.opendasharchive.openarchive.features.core.BaseFragment
 import net.opendasharchive.openarchive.features.core.ToolbarConfigurable
 import net.opendasharchive.openarchive.features.core.UiText
 import net.opendasharchive.openarchive.features.core.dialog.DialogStateManager
 import net.opendasharchive.openarchive.features.core.dialog.showDialog
-import net.opendasharchive.openarchive.features.onboarding.SpaceSetupActivity
-import net.opendasharchive.openarchive.services.snowbird.SnowbirdGroupViewModel
-import net.opendasharchive.openarchive.services.snowbird.SnowbirdRepoViewModel
 import net.opendasharchive.openarchive.util.FullScreenOverlayManager
+import org.koin.android.ext.android.inject
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
-abstract class BaseSnowbirdFragment : BaseFragment() {
+abstract class BaseSnowbirdFragment : Fragment(), ToolbarConfigurable {
+
+    protected val dialogManager: DialogStateManager by activityViewModel()
+    protected val analyticsManager: AnalyticsManager by inject()
+    protected val sessionTracker: SessionTracker by inject()
+
+    private var screenStartTime: Long = 0
+    private var previousScreen: String = ""
 
     val snowbirdGroupViewModel: SnowbirdGroupViewModel by androidViewModel()
     val snowbirdRepoViewModel: SnowbirdRepoViewModel by androidViewModel()
+
+    protected open fun getScreenName(): String = this::class.simpleName ?: "UnknownSnowbirdFragment"
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -59,6 +70,33 @@ abstract class BaseSnowbirdFragment : BaseFragment() {
 
     override fun onResume() {
         super.onResume()
-        (activity as? SpaceSetupActivity)?.updateToolbarFromFragment(this)
+        (activity as? SnowbirdActivity)?.updateToolbarFromFragment(this)
+
+        screenStartTime = System.currentTimeMillis()
+        val screenName = getScreenName()
+        AppLogger.setCurrentScreen(screenName)
+
+        lifecycleScope.launch {
+            analyticsManager.trackScreenView(screenName, null, previousScreen)
+        }
+        sessionTracker.setCurrentScreen(screenName)
+
+        if (previousScreen.isNotEmpty() && previousScreen != screenName) {
+            lifecycleScope.launch {
+                analyticsManager.trackNavigation(previousScreen, screenName)
+            }
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        val timeSpent = (System.currentTimeMillis() - screenStartTime) / 1000
+        val screenName = getScreenName()
+
+        lifecycleScope.launch {
+            analyticsManager.trackScreenView(screenName, timeSpent, previousScreen)
+        }
+
+        previousScreen = screenName
     }
 }

--- a/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdActivity.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdActivity.kt
@@ -1,0 +1,65 @@
+package net.opendasharchive.openarchive.services.snowbird
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavController
+import androidx.navigation.NavGraph
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.ui.AppBarConfiguration
+import androidx.navigation.ui.setupActionBarWithNavController
+import net.opendasharchive.openarchive.R
+import net.opendasharchive.openarchive.databinding.ActivitySnowbirdBinding
+import net.opendasharchive.openarchive.features.core.BaseActivity
+import net.opendasharchive.openarchive.features.core.ToolbarConfigurable
+
+
+class SnowbirdActivity : BaseActivity() {
+
+    private lateinit var binding: ActivitySnowbirdBinding
+    private lateinit var navController: NavController
+    private lateinit var navGraph: NavGraph
+    private lateinit var appBarConfiguration: AppBarConfiguration
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        binding = ActivitySnowbirdBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setupToolbar(showBackButton = true)
+        initSnowbirdNavigation()
+    }
+
+    private fun initSnowbirdNavigation() {
+        val navHostFragment = supportFragmentManager.findFragmentById(R.id.snowbird_nav_host_fragment) as NavHostFragment
+
+        navController = navHostFragment.navController
+        navGraph = navController.navInflater.inflate(R.navigation.snowbird_nav_graph)
+
+        appBarConfiguration = AppBarConfiguration(emptySet())
+        setupActionBarWithNavController(navController, appBarConfiguration)
+    }
+
+    fun updateToolbarFromFragment(fragment: Fragment) {
+        if (fragment is ToolbarConfigurable) {
+            val title = fragment.getToolbarTitle()
+            val subtitle = fragment.getToolbarSubtitle()
+            val showBackButton = fragment.shouldShowBackButton()
+            setupToolbar(title = title, showBackButton = showBackButton)
+            supportActionBar?.subtitle = subtitle
+        } else {
+            setupToolbar(title = getString(R.string.dweb_title), showBackButton = true)
+            supportActionBar?.subtitle = null
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        return if (::navController.isInitialized && navController.currentDestination?.id == R.id.snowbird_dashboard) {
+            finish()
+            true
+        } else {
+            navController.navigateUp() || super.onSupportNavigateUp()
+        }
+    }
+}

--- a/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdCreateGroupFragment.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdCreateGroupFragment.kt
@@ -21,8 +21,6 @@ import net.opendasharchive.openarchive.databinding.FragmentSnowbirdCreateGroupBi
 import net.opendasharchive.openarchive.db.SnowbirdError
 import net.opendasharchive.openarchive.db.SnowbirdGroup
 import net.opendasharchive.openarchive.db.SnowbirdRepo
-import net.opendasharchive.openarchive.db.Space
-import net.opendasharchive.openarchive.features.core.BaseFragment
 import net.opendasharchive.openarchive.util.FullScreenOverlayCreateGroupManager
 import net.opendasharchive.openarchive.util.extensions.applyEdgeToEdgeInsets
 import java.io.File
@@ -158,9 +156,8 @@ class SnowbirdCreateGroupFragment : BaseSnowbirdFragment() {
         }
 
         val action = SnowbirdCreateGroupFragmentDirections
-            .actionFragmentSnowbirdCreateGroupToFragmentSpaceSetupSuccess(
+            .actionFragmentSnowbirdCreateGroupToFragmentSnowbirdSetupSuccess(
                 message = getString(R.string.you_have_successfully_created_dweb),
-                spaceType = Space.Type.RAVEN,
                 dwebGroupKey = group.key,
             )
         findNavController().navigate(action)

--- a/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdJoinGroupFragment.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdJoinGroupFragment.kt
@@ -17,10 +17,8 @@ import net.opendasharchive.openarchive.databinding.FragmentSnowbirdJoinGroupBind
 import net.opendasharchive.openarchive.db.SnowbirdError
 import net.opendasharchive.openarchive.db.SnowbirdGroup
 import net.opendasharchive.openarchive.db.SnowbirdRepo
-import net.opendasharchive.openarchive.db.Space
 import net.opendasharchive.openarchive.extensions.getQueryParameter
 import net.opendasharchive.openarchive.extensions.showKeyboard
-import net.opendasharchive.openarchive.features.core.BaseFragment
 import net.opendasharchive.openarchive.features.core.UiText
 import net.opendasharchive.openarchive.features.core.dialog.DialogType
 import net.opendasharchive.openarchive.features.core.dialog.showDialog
@@ -138,9 +136,8 @@ class SnowbirdJoinGroupFragment: BaseSnowbirdFragment() {
                 text = UiText.StringResource(R.string.label_got_it)
                 action = {
 
-                    val action = SnowbirdJoinGroupFragmentDirections.actionFragmentSnowbirdJoinGroupToFragmentSpaceSetupSuccess(
+                    val action = SnowbirdJoinGroupFragmentDirections.actionFragmentSnowbirdJoinGroupToFragmentSnowbirdSetupSuccess(
                         message = getString(R.string.you_have_successfully_joined_dweb),
-                        spaceType = Space.Type.RAVEN,
                         dwebGroupKey = groupKey
                     )
 

--- a/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdSetupSuccessFragment.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdSetupSuccessFragment.kt
@@ -1,0 +1,95 @@
+package net.opendasharchive.openarchive.services.snowbird
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.MenuProvider
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import androidx.navigation.navOptions
+import net.opendasharchive.openarchive.R
+import net.opendasharchive.openarchive.databinding.FragmentSpaceSetupSuccessBinding
+import net.opendasharchive.openarchive.util.extensions.applyEdgeToEdgeInsets
+
+class SnowbirdSetupSuccessFragment : BaseSnowbirdFragment() {
+
+    private lateinit var binding: FragmentSpaceSetupSuccessBinding
+    private val args: SnowbirdSetupSuccessFragmentArgs by navArgs()
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentSpaceSetupSuccessBinding.inflate(inflater)
+
+        binding.mainContainer.applyEdgeToEdgeInsets(
+            typeMask = WindowInsetsCompat.Type.navigationBars()
+        ) { insets ->
+            bottomMargin = insets.bottom
+        }
+
+        binding.buttonBar.applyEdgeToEdgeInsets(
+            typeMask = WindowInsetsCompat.Type.navigationBars()
+        ) { insets ->
+            bottomMargin = insets.bottom
+        }
+
+        if (args.message.isNotEmpty()) {
+            binding.successMessage.text = args.message
+        }
+
+        binding.btAuthenticate.setOnClickListener { _ ->
+            val navController = findNavController()
+            // Navigate to Snowbird Dashboard and clear this success screen from back stack
+            navController.navigate(
+                R.id.snowbird_dashboard,
+                null,
+                navOptions {
+                    // Clear the entire Snowbird graph so dashboard becomes the new root
+                    popUpTo(R.id.snowbird_nav_graph) { inclusive = true }
+                    launchSingleTop = true
+                }
+            )
+        }
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+
+            // Add the menu provider
+            requireActivity().addMenuProvider(object : MenuProvider {
+                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                    menuInflater.inflate(R.menu.menu_space_setup_success, menu)
+                }
+
+                override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                    return when (menuItem.itemId) {
+                        R.id.action_share_group -> {
+                            val action = SnowbirdSetupSuccessFragmentDirections.actionFragmentSnowbirdSetupSuccessToFragmentSnowbirdShareGroup(
+                                    dwebGroupKey = args.dwebGroupKey,
+                                    isSetupOngoing = true
+                                )
+
+                            findNavController().navigate(action)
+                            true
+                        }
+
+                        else -> false
+                    }
+                }
+            }, viewLifecycleOwner)
+
+    }
+
+    override fun getToolbarTitle() = getString(R.string.space_setup_success_title)
+    override fun shouldShowBackButton() = false
+
+}

--- a/app/src/main/res/layout/activity_snowbird.xml
+++ b/app/src/main/res/layout/activity_snowbird.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.view.insets.ProtectionLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/snowbird_protection"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true"
+        android:filterTouchesWhenObscured="true"
+        android:orientation="vertical"
+        tools:context=".services.snowbird.SnowbirdActivity">
+
+        <include
+            android:id="@+id/common_app_bar"
+            layout="@layout/common_app_bar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/snowbird_nav_host_fragment"
+            android:name="androidx.navigation.fragment.compose.ComposableNavHostFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:defaultNavHost="true"
+            app:navGraph="@navigation/snowbird_nav_graph" />
+
+    </LinearLayout>
+</androidx.core.view.insets.ProtectionLayout>

--- a/app/src/main/res/navigation/app_nav_graph.xml
+++ b/app/src/main/res/navigation/app_nav_graph.xml
@@ -22,13 +22,6 @@
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
             app:popExitAnim="@anim/slide_out_right" />
-        <action
-            android:id="@+id/action_fragment_space_list_to_fragment_snowbird"
-            app:destination="@id/snowbird_nav_graph"
-            app:enterAnim="@anim/slide_in_right"
-            app:exitAnim="@anim/slide_out_left"
-            app:popEnterAnim="@anim/slide_in_left"
-            app:popExitAnim="@anim/slide_out_right" />
 
         <action
             android:id="@+id/action_fragment_space_list_to_internet_archive_details"
@@ -55,14 +48,6 @@
         <action
             android:id="@+id/action_fragment_space_setup_to_internet_archive_login"
             app:destination="@id/fragment_internet_archive_login"
-            app:enterAnim="@anim/slide_in_right"
-            app:exitAnim="@anim/slide_out_left"
-            app:popEnterAnim="@anim/slide_in_left"
-            app:popExitAnim="@anim/slide_out_right" />
-
-        <action
-            android:id="@+id/action_fragment_space_setup_to_fragment_snowbird"
-            app:destination="@id/snowbird_nav_graph"
             app:enterAnim="@anim/slide_in_right"
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
@@ -142,25 +127,7 @@
         <argument
             android:name="space_type"
             app:argType="net.opendasharchive.openarchive.db.Space$Type" />
-        <argument
-            android:name="dweb_group_key"
-            app:argType="string"
-            android:defaultValue="null"
-            app:nullable="true"/>
-        <action
-            android:id="@+id/action_fragment_space_setup_success_to_fragment_snowbird_share_group"
-            app:destination="@id/fragment_snowbird_share_group">
-            <argument
-                android:name="dweb_group_key"
-                app:argType="string" />
-            <argument
-                android:name="is_setup_ongoing"
-                app:argType="boolean"
-                android:defaultValue="false" />
-        </action>
-        <action
-            android:id="@+id/action_fragment_space_setup_success_to_fragment_snowbird"
-            app:destination="@id/snowbird_nav_graph" />
+
 
     </fragment>
 
@@ -237,7 +204,4 @@
         android:name="net.opendasharchive.openarchive.features.settings.SettingsFragment"
         />
 
-
-
-    <include app:graph="@navigation/snowbird_nav_graph" />
 </navigation>

--- a/app/src/main/res/navigation/snowbird_nav_graph.xml
+++ b/app/src/main/res/navigation/snowbird_nav_graph.xml
@@ -7,29 +7,29 @@
     app:exitAnim="@anim/slide_out_left"
     app:popEnterAnim="@anim/slide_in_left"
     app:popExitAnim="@anim/slide_out_right"
-    app:startDestination="@id/fragment_snowbird">
+    app:startDestination="@id/snowbird_dashboard">
 
     <fragment
-        android:id="@+id/fragment_snowbird"
+        android:id="@+id/snowbird_dashboard"
         android:name="net.opendasharchive.openarchive.services.snowbird.SnowbirdFragment"
         tools:layout="@layout/fragment_snowbird">
         <action
             android:id="@+id/action_fragment_snowbird_to_fragment_snowbird_group_list"
-            app:destination="@id/fragment_snowbird_group_list"
+            app:destination="@id/snowbird_group_list"
             app:enterAnim="@anim/slide_in_right"
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
             app:popExitAnim="@anim/slide_out_right" />
         <action
             android:id="@+id/action_fragment_snowbird_to_fragment_snowbird_join_group"
-            app:destination="@id/fragment_snowbird_join_group"
+            app:destination="@id/snowbird_join_group"
             app:enterAnim="@anim/slide_in_right"
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
             app:popExitAnim="@anim/slide_out_right" />
         <action
             android:id="@+id/action_fragment_snowbird_to_fragment_snowbird_create_group"
-            app:destination="@id/fragment_snowbird_create_group"
+            app:destination="@id/snowbird_create_group"
             app:enterAnim="@anim/slide_in_right"
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
@@ -37,26 +37,26 @@
     </fragment>
 
     <fragment
-        android:id="@+id/fragment_snowbird_group_list"
+        android:id="@+id/snowbird_group_list"
         android:name="net.opendasharchive.openarchive.services.snowbird.SnowbirdGroupListFragment"
         tools:layout="@layout/fragment_snowbird_group_list">
         <action
             android:id="@+id/action_fragment_snowbird_group_list_to_fragment_snowbird_create_group"
-            app:destination="@id/fragment_snowbird_create_group"
+            app:destination="@id/snowbird_create_group"
             app:enterAnim="@anim/slide_in_right"
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
             app:popExitAnim="@anim/slide_out_right" />
         <action
             android:id="@+id/action_fragment_snowbird_group_list_to_fragment_snowbird_list_repos"
-            app:destination="@id/fragment_snowbird_list_repos"
+            app:destination="@id/snowbird_list_repos"
             app:enterAnim="@anim/slide_in_right"
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
             app:popExitAnim="@anim/slide_out_right" />
         <action
             android:id="@+id/action_fragment_snowbird_group_list_to_fragment_snowbird_share_group"
-            app:destination="@id/fragment_snowbird_share_group"
+            app:destination="@id/snowbird_share_group_fragment"
             app:enterAnim="@anim/slide_in_right"
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
@@ -64,19 +64,20 @@
     </fragment>
 
     <fragment
-        android:id="@+id/fragment_snowbird_create_group"
+        android:id="@+id/snowbird_create_group"
         android:name="net.opendasharchive.openarchive.services.snowbird.SnowbirdCreateGroupFragment"
         tools:layout="@layout/fragment_snowbird_create_group">
         <action
             android:id="@+id/action_fragment_snowbird_create_group_to_fragment_snowbird_share_group"
-            app:destination="@id/fragment_snowbird_share_group"
+            app:destination="@id/snowbird_share_group_fragment"
             app:enterAnim="@anim/slide_in_right"
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
             app:popExitAnim="@anim/slide_out_right" />
+
         <action
-            android:id="@+id/action_fragment_snowbird_create_group_to_fragment_space_setup_success"
-            app:destination="@id/fragment_space_setup_success"
+            android:id="@+id/action_fragment_snowbird_create_group_to_fragment_snowbird_setup_success"
+            app:destination="@id/snowbird_setup_success"
             app:enterAnim="@anim/slide_in_right"
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
@@ -84,9 +85,7 @@
             <argument
                 android:name="message"
                 app:argType="string" />
-            <argument
-                android:name="space_type"
-                app:argType="net.opendasharchive.openarchive.db.Space$Type" />
+
             <argument
                 android:name="dweb_group_key"
                 app:argType="string"
@@ -96,7 +95,7 @@
     </fragment>
 
     <fragment
-        android:id="@+id/fragment_snowbird_join_group"
+        android:id="@+id/snowbird_join_group"
         android:name="net.opendasharchive.openarchive.services.snowbird.SnowbirdJoinGroupFragment"
         tools:layout="@layout/fragment_snowbird_join_group">
         <argument
@@ -106,9 +105,10 @@
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
             app:popExitAnim="@anim/slide_out_right" />
+
         <action
-            android:id="@+id/action_fragment_snowbird_join_group_to_fragment_space_setup_success"
-            app:destination="@id/fragment_space_setup_success"
+            android:id="@+id/action_fragment_snowbird_join_group_to_fragment_snowbird_setup_success"
+            app:destination="@id/snowbird_setup_success"
             app:enterAnim="@anim/slide_in_right"
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
@@ -116,9 +116,7 @@
             <argument
                 android:name="message"
                 app:argType="string" />
-            <argument
-                android:name="space_type"
-                app:argType="net.opendasharchive.openarchive.db.Space$Type" />
+
             <argument
                 android:name="dweb_group_key"
                 app:argType="string"
@@ -128,12 +126,12 @@
     </fragment>
 
     <fragment
-        android:id="@+id/fragment_snowbird_list_repos"
+        android:id="@+id/snowbird_list_repos"
         android:name="net.opendasharchive.openarchive.services.snowbird.SnowbirdRepoListFragment"
         tools:layout="@layout/fragment_snowbird_list_repos">
         <action
             android:id="@+id/action_fragment_snowbird_list_repos_to_fragment_snowbird_list_media"
-            app:destination="@id/fragment_snowbird_list_media"
+            app:destination="@id/snowbird_list_media"
             app:enterAnim="@anim/slide_in_right"
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
@@ -144,7 +142,7 @@
     </fragment>
 
     <fragment
-        android:id="@+id/fragment_snowbird_share_group"
+        android:id="@+id/snowbird_share_group_fragment"
         android:name="net.opendasharchive.openarchive.services.snowbird.SnowbirdShareFragment"
         tools:layout="@layout/fragment_snowbird_share_group">
         <argument
@@ -157,7 +155,7 @@
     </fragment>
 
     <fragment
-        android:id="@+id/fragment_snowbird_list_media"
+        android:id="@+id/snowbird_list_media"
         android:name="net.opendasharchive.openarchive.services.snowbird.SnowbirdFileListFragment"
         tools:layout="@layout/fragment_snowbird_list_media">
         <argument
@@ -169,7 +167,7 @@
     </fragment>
 
     <fragment
-        android:id="@+id/fragment_snowbird_group_overview"
+        android:id="@+id/snowbird_group_overview"
         android:name="net.opendasharchive.openarchive.services.snowbird.SnowbirdGroupOverviewFragment"
         tools:layout="@layout/fragment_snowbird_group_overview">
         <argument
@@ -178,5 +176,24 @@
         <argument
             android:name="dweb_repo_key"
             app:argType="string" />
+    </fragment>
+
+
+    <fragment
+        android:id="@+id/snowbird_setup_success"
+        android:name="net.opendasharchive.openarchive.services.snowbird.SnowbirdSetupSuccessFragment"
+        tools:layout="@layout/fragment_space_setup_success">
+        <argument
+            android:name="message"
+            app:argType="string" />
+
+        <argument
+            android:name="dweb_group_key"
+            app:argType="string"/>
+
+        <action
+            android:id="@+id/action_fragment_snowbird_setup_success_to_fragment_snowbird_share_group"
+            app:destination="@id/snowbird_share_group_fragment"/>
+
     </fragment>
 </navigation>


### PR DESCRIPTION
Extracted Dweb into separate activity
decoupled from Main App

What / Why

  - Isolated Snowbird flows into their own SnowbirdActivity with a dedicated nav graph and host layout, removing cross-activity fragment navigation.
  - Added Snowbird-specific success screen (SnowbirdSetupSuccessFragment) and rewired create/join flows to launch success directly without hopping through SpaceSetupActivity.
  - Updated success navigation to reset the Snowbird back stack to the dashboard and ensure the toolbar/back button exits to the previous activity when on the dashboard.
  - Simplified Snowbird fragments to assume a single host (SnowbirdActivity), removing fallback host checks and redundant SafeArgs handling.

  Key Changes

  - New SnowbirdActivity and layout; manifest entry for Snowbird.
  - Snowbird nav graph now starts at the dashboard, includes the Snowbird success screen, and routes create/join → success → dashboard/share.
  - SnowbirdSetupSuccessFragment uses nav ID navigation (no ActionOnlyNavDirections) and pops up to the graph root to avoid back-stack loops.
  - BaseSnowbirdFragment now owns dialog/analytics lifecycle and toolbar updates for Snowbird only.