### PR TITLE
Reference: snowbird readiness notes

### DIFF
--- a/app/src/main/java/net/opendasharchive/openarchive/db/FileUploadResult.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/db/FileUploadResult.kt
@@ -6,5 +6,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class FileUploadResult (
     var name: String,
-    @SerialName("updated_collection_hash") var updatedCollectionHash: String
+    @SerialName("updated_collection_hash") var updatedCollectionHash: String,
+    @SerialName("file_hash") var fileHash: String? = null
 ) : SerializableMarker

--- a/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdBridge.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdBridge.kt
@@ -28,7 +28,8 @@ class SnowbirdBridge {
 
         @JvmStatic
         fun updateStatusFromRust(code: Int, message: String) {
-            instance?._status?.value = SnowbirdServiceStatus.fromCode(code)
+            // Preserve error context from Rust when available.
+            instance?._status?.value = SnowbirdServiceStatus.fromCode(code, message)
         }
     }
 

--- a/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdFileListFragment.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdFileListFragment.kt
@@ -519,13 +519,16 @@ class SnowbirdFileListFragment : BaseSnowbirdFragment() {
     private fun onFileUploaded(result: FileUploadResult) {
         handleLoadingStatus(false)
         Timber.d("File successfully uploaded: $result")
-        SnowbirdFileItem(
-            name = result.name,
-            hash = result.updatedCollectionHash,
-            groupKey = groupKey,
-            repoKey = repoKey,
-            isDownloaded = true
-        ).save()
+        val uploadedHash = result.fileHash
+        if (!uploadedHash.isNullOrBlank()) {
+            SnowbirdFileItem(
+                name = result.name,
+                hash = uploadedHash,
+                groupKey = groupKey,
+                repoKey = repoKey,
+                isDownloaded = true
+            ).save()
+        }
         snowbirdFileViewModel.fetchFiles(groupKey, repoKey, forceRefresh = false)
     }
 

--- a/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdFileRepository.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdFileRepository.kt
@@ -3,9 +3,12 @@ package net.opendasharchive.openarchive.services.snowbird
 import android.net.Uri
 import net.opendasharchive.openarchive.db.FileUploadResult
 import net.opendasharchive.openarchive.db.SnowbirdFileItem
+import net.opendasharchive.openarchive.db.SnowbirdError
 import net.opendasharchive.openarchive.db.toFile
 import net.opendasharchive.openarchive.extensions.toSnowbirdError
 import net.opendasharchive.openarchive.services.snowbird.service.ISnowbirdAPI
+import net.opendasharchive.openarchive.services.snowbird.service.ServiceStatus
+import net.opendasharchive.openarchive.services.snowbird.service.SnowbirdService
 
 interface ISnowbirdFileRepository {
     suspend fun fetchFiles(groupKey: String, repoKey: String, forceRefresh: Boolean = false): SnowbirdResult<List<SnowbirdFileItem>>
@@ -14,6 +17,14 @@ interface ISnowbirdFileRepository {
 }
 
 class SnowbirdFileRepository(val api: ISnowbirdAPI) : ISnowbirdFileRepository {
+
+    private fun ensureServerReadyForNetwork(): SnowbirdResult.Error? {
+        return if (SnowbirdService.getCurrentStatus() is ServiceStatus.Connected) {
+            null
+        } else {
+            SnowbirdResult.Error(SnowbirdError.GeneralError("DWeb server is not ready. Enable DWeb Server and wait for it to connect."))
+        }
+    }
 
     override suspend fun fetchFiles(groupKey: String, repoKey: String, forceRefresh: Boolean): SnowbirdResult<List<SnowbirdFileItem>> {
         return if (forceRefresh) {
@@ -29,6 +40,7 @@ class SnowbirdFileRepository(val api: ISnowbirdAPI) : ISnowbirdFileRepository {
 
     private suspend fun fetchFilesFromNetwork(groupKey: String, repoKey: String): SnowbirdResult<List<SnowbirdFileItem>> {
         return try {
+            ensureServerReadyForNetwork()?.let { return it }
             val response = api.fetchFiles(groupKey, repoKey)
             val files = response.files.map { it.toFile(groupKey = groupKey, repoKey = repoKey) }
             SnowbirdResult.Success(files)
@@ -39,6 +51,7 @@ class SnowbirdFileRepository(val api: ISnowbirdAPI) : ISnowbirdFileRepository {
 
     override suspend fun downloadFile(groupKey: String, repoKey: String, filename: String): SnowbirdResult<ByteArray> {
         return try {
+            ensureServerReadyForNetwork()?.let { return it }
             val response = api.downloadFile(groupKey, repoKey, filename)
             SnowbirdResult.Success(response)
         } catch (e: Exception) {
@@ -48,6 +61,7 @@ class SnowbirdFileRepository(val api: ISnowbirdAPI) : ISnowbirdFileRepository {
 
     override suspend fun uploadFile(groupKey: String, repoKey: String, uri: Uri): SnowbirdResult<FileUploadResult> {
         return try {
+            ensureServerReadyForNetwork()?.let { return it }
             val response = api.uploadFile(groupKey, repoKey, uri)
             SnowbirdResult.Success(response)
         } catch (e: Exception) {

--- a/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdGroupListFragment.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdGroupListFragment.kt
@@ -51,7 +51,8 @@ class SnowbirdGroupListFragment : BaseSnowbirdFragment() {
         setupRecyclerView()
         initializeViewModelObservers()
 
-        snowbirdGroupViewModel.fetchGroups()
+        // Use network on first load so new memberships appear without restart.
+        snowbirdGroupViewModel.fetchGroups(forceRefresh = true)
     }
 
     private fun setupSwipeRefresh() {

--- a/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdGroupRepository.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdGroupRepository.kt
@@ -4,8 +4,11 @@ import net.opendasharchive.openarchive.db.JoinGroupResponse
 import net.opendasharchive.openarchive.db.MembershipRequest
 import net.opendasharchive.openarchive.db.RequestName
 import net.opendasharchive.openarchive.db.SnowbirdGroup
+import net.opendasharchive.openarchive.db.SnowbirdError
 import net.opendasharchive.openarchive.extensions.toSnowbirdError
 import net.opendasharchive.openarchive.services.snowbird.service.ISnowbirdAPI
+import net.opendasharchive.openarchive.services.snowbird.service.ServiceStatus
+import net.opendasharchive.openarchive.services.snowbird.service.SnowbirdService
 
 interface ISnowbirdGroupRepository {
     suspend fun createGroup(groupName: String): SnowbirdResult<SnowbirdGroup>
@@ -18,8 +21,17 @@ class SnowbirdGroupRepository(val api: ISnowbirdAPI) : ISnowbirdGroupRepository 
     private var lastFetchTime: Long = 0
     private val cacheValidityPeriod: Long = 5 * 60 * 1000
 
+    private fun ensureServerReadyForNetwork(): SnowbirdResult.Error? {
+        return if (SnowbirdService.getCurrentStatus() is ServiceStatus.Connected) {
+            null
+        } else {
+            SnowbirdResult.Error(SnowbirdError.GeneralError("DWeb server is not ready. Enable DWeb Server and wait for it to connect."))
+        }
+    }
+
     override suspend fun createGroup(groupName: String): SnowbirdResult<SnowbirdGroup> {
         return try {
+            ensureServerReadyForNetwork()?.let { return it }
             val response = api.createGroup(
                 RequestName(groupName)
             )
@@ -31,6 +43,7 @@ class SnowbirdGroupRepository(val api: ISnowbirdAPI) : ISnowbirdGroupRepository 
 
     override suspend fun fetchGroup(groupKey: String): SnowbirdResult<SnowbirdGroup> {
         return try {
+            ensureServerReadyForNetwork()?.let { return it }
             val response = api.fetchGroup(groupKey)
             SnowbirdResult.Success(response)
         } catch (e: Exception) {
@@ -42,7 +55,7 @@ class SnowbirdGroupRepository(val api: ISnowbirdAPI) : ISnowbirdGroupRepository 
         val currentTime = System.currentTimeMillis()
         val shouldFetchFromNetwork = forceRefresh || currentTime - lastFetchTime > cacheValidityPeriod
 
-        return if (forceRefresh) {
+        return if (shouldFetchFromNetwork) {
             fetchFromNetwork()
         } else {
             fetchFromCache()
@@ -51,6 +64,7 @@ class SnowbirdGroupRepository(val api: ISnowbirdAPI) : ISnowbirdGroupRepository 
 
     override suspend fun joinGroup(uriString: String): SnowbirdResult<JoinGroupResponse> {
         return try {
+            ensureServerReadyForNetwork()?.let { return it }
             val response = api.joinGroup(
                 MembershipRequest(uriString)
             )
@@ -63,7 +77,9 @@ class SnowbirdGroupRepository(val api: ISnowbirdAPI) : ISnowbirdGroupRepository 
 
     private suspend fun fetchFromNetwork(): SnowbirdResult<List<SnowbirdGroup>> {
         return try {
+            ensureServerReadyForNetwork()?.let { return it }
             val response = api.fetchGroups()
+            lastFetchTime = System.currentTimeMillis()
             SnowbirdResult.Success(response.groups)
         } catch (e: Exception) {
             SnowbirdResult.Error(e.toSnowbirdError())

--- a/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdGroupViewModel.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdGroupViewModel.kt
@@ -59,7 +59,9 @@ class SnowbirdGroupViewModel(
         viewModelScope.launch {
             _groupState.value = GroupState.Loading
             try {
-                val result = processingTracker.trackProcessingWithTimeout(60_000, "fetch_groups") {
+                // Use longer timeout for refresh operations that may need to download collections from peers
+                val timeoutMs = if (forceRefresh) 120_000L else 60_000L
+                val result = processingTracker.trackProcessingWithTimeout(timeoutMs, "fetch_groups") {
                     repository.fetchGroups(forceRefresh)
                 }
 

--- a/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdRepoRepository.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdRepoRepository.kt
@@ -5,10 +5,13 @@ import kotlinx.serialization.Serializable
 import net.opendasharchive.openarchive.db.RefreshGroupResponse
 import net.opendasharchive.openarchive.db.RequestName
 import net.opendasharchive.openarchive.db.SnowbirdGroup
+import net.opendasharchive.openarchive.db.SnowbirdError
 import net.opendasharchive.openarchive.db.SnowbirdRepo
 import net.opendasharchive.openarchive.db.toRepo
 import net.opendasharchive.openarchive.extensions.toSnowbirdError
 import net.opendasharchive.openarchive.services.snowbird.service.ISnowbirdAPI
+import net.opendasharchive.openarchive.services.snowbird.service.ServiceStatus
+import net.opendasharchive.openarchive.services.snowbird.service.SnowbirdService
 import timber.log.Timber
 
 interface ISnowbirdRepoRepository {
@@ -19,10 +22,19 @@ interface ISnowbirdRepoRepository {
 
 class SnowbirdRepoRepository(val api: ISnowbirdAPI) : ISnowbirdRepoRepository {
 
+    private fun ensureServerReadyForNetwork(): SnowbirdResult.Error? {
+        return if (SnowbirdService.getCurrentStatus() is ServiceStatus.Connected) {
+            null
+        } else {
+            SnowbirdResult.Error(SnowbirdError.GeneralError("DWeb server is not ready. Enable DWeb Server and wait for it to connect."))
+        }
+    }
+
     override suspend fun createRepo(groupKey: String, repoName: String): SnowbirdResult<SnowbirdRepo> {
         Timber.d("Creating repo: groupKey=$groupKey, repoName=$repoName")
 
         return try {
+            ensureServerReadyForNetwork()?.let { return it }
             val response = api.createRepo(groupKey, RequestName(repoName))
             val repo = response.toRepo(groupKey)
             SnowbirdResult.Success(repo)
@@ -41,6 +53,7 @@ class SnowbirdRepoRepository(val api: ISnowbirdAPI) : ISnowbirdRepoRepository {
 
     private suspend fun fetchFromNetwork(groupKey: String): SnowbirdResult<List<SnowbirdRepo>> {
         return try {
+            ensureServerReadyForNetwork()?.let { return it }
             val response = api.fetchRepos(groupKey)
             val repoList = response.repos.map { it.toRepo(groupKey) }
             SnowbirdResult.Success(repoList)
@@ -55,6 +68,7 @@ class SnowbirdRepoRepository(val api: ISnowbirdAPI) : ISnowbirdRepoRepository {
 
     override suspend fun refreshGroupContent(groupKey: String): SnowbirdResult<RefreshGroupResponse> {
         return try {
+            ensureServerReadyForNetwork()?.let { return it }
             val response = api.refreshGroupContent(groupKey)
             SnowbirdResult.Success(response)
         } catch (e: Exception) {

--- a/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdRepoViewModel.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdRepoViewModel.kt
@@ -90,20 +90,37 @@ class SnowbirdRepoViewModel(
 
                     is SnowbirdResult.Success<RefreshGroupResponse> -> {
                         AppLogger.i("Group content refreshed successfully")
-                        //TODO: Save Repo List and Media List to DB
 
-                        // Get existing repos for group
+                        // Only persist refresh data for repos that belong to this group.
+                        val allowedRepoIds: Set<String> = run {
+                            val fromNetwork = repository.fetchRepos(groupKey, forceRefresh = true)
+                            when (fromNetwork) {
+                                is SnowbirdResult.Success -> fromNetwork.value.map { it.key }.toSet()
+                                is SnowbirdResult.Error -> {
+                                    AppLogger.w("Unable to fetch repos for scoping refresh; falling back to local DB scope: ${fromNetwork.error.friendlyMessage}")
+                                    SnowbirdRepo.getAllForGroupKey(groupKey).map { it.key }.toSet()
+                                }
+                            }
+                        }
+
                         val existingRepos = SnowbirdRepo.getAllForGroupKey(groupKey)
                         val existingReposMap = existingRepos.associateBy { it.key }
 
-                        result.value.refreshedRepos.forEach  { repoData ->
+                        val repoErrors = mutableListOf<String>()
 
-                            // Log repo errors if any
-                            if (!repoData.error.isNullOrEmpty()) {
-                                AppLogger.e("Error refreshing repo ${repoData.repoId}: ${repoData.error}")
+                        result.value.refreshedRepos.forEach  { repoData ->
+                            if (allowedRepoIds.isNotEmpty() && !allowedRepoIds.contains(repoData.repoId)) {
+                                AppLogger.e("Refresh returned repo outside group scope. groupKey=$groupKey repoId=${repoData.repoId} name=${repoData.name}")
+                                return@forEach
                             }
 
-                            // Update or create repo
+                            if (!repoData.error.isNullOrEmpty()) {
+                                val bucket = classifyRefreshError(repoData.error)
+                                val msg = "Repo ${repoData.name} (${repoData.repoId}): $bucket — ${repoData.error}"
+                                repoErrors.add(msg)
+                                AppLogger.e(msg)
+                            }
+
                             val snowbirdRepo = existingReposMap[repoData.repoId] ?: repoData.toRepo().apply {
                                 this.groupKey = groupKey
                             }
@@ -113,29 +130,34 @@ class SnowbirdRepoViewModel(
                                 permissions = if (repoData.canWrite) "READ_WRITE" else "READ_ONLY"
                             }.save()
 
-                            // Get existing files for this repo
                             val existingFiles = SnowbirdFileItem.findBy(groupKey, repoData.repoId)
                             val existingFilesMap = existingFiles.associateBy { it.name }
 
-                            // Process all files (not just refreshed ones)
                             repoData.allFiles.forEach { fileName ->
                                 val existingFile = existingFilesMap[fileName]
 
                                 if (existingFile == null) {
-                                    // Create new file if it doesn't exist
                                     SnowbirdFileItem(
                                         name = fileName,
                                         repoKey = repoData.repoId,
                                         groupKey = groupKey,
                                     ).save()
-                                } else {
-                                    // Update existing file without overwriting with null
-                                    // Note: The refresh API doesn't provide file details,
-                                    // so we just maintain the existing file record
                                 }
                             }
                         }
-                        _repoState.value = RepoState.RefreshGroupContentSuccess
+
+                        // Surface per-repo refresh failures while keeping persisted updates.
+                        if (repoErrors.isNotEmpty()) {
+                            val summary = repoErrors.take(8).joinToString("\n")
+                            val suffix = if (repoErrors.size > 8) "\n… and ${repoErrors.size - 8} more" else ""
+                            _repoState.value = RepoState.Error(
+                                SnowbirdError.GeneralError(
+                                    "Some repositories failed to refresh:\n$summary$suffix\n\n(Types: DHT_DISCOVERY vs PEER_DOWNLOAD vs UNKNOWN)"
+                                )
+                            )
+                        } else {
+                            _repoState.value = RepoState.RefreshGroupContentSuccess
+                        }
                         fetchRepos(groupKey = groupKey)
                     }
                 }
@@ -143,6 +165,15 @@ class SnowbirdRepoViewModel(
             } catch (e: TimeoutCancellationException) {
                 _repoState.value = RepoState.Error(SnowbirdError.TimedOut)
             }
+        }
+    }
+
+    private fun classifyRefreshError(message: String): String {
+        val m = message.lowercase()
+        return when {
+            "dht" in m || "repo root hash" in m -> "DHT_DISCOVERY"
+            "download from any peer" in m || "any peer" in m -> "PEER_DOWNLOAD"
+            else -> "UNKNOWN"
         }
     }
 }

--- a/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/service/SnowbirdService.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/services/snowbird/service/SnowbirdService.kt
@@ -90,8 +90,18 @@ class SnowbirdService : Service() {
             createNotification("Snowbird Server is starting up.")
         )
 
-        // Launch a coroutine to check & start
+        // Launch startup flow
         serviceScope.launch {
+            // Initialize bridge first to reduce startup race windows.
+            try {
+                withContext(Dispatchers.IO) {
+                    SnowbirdBridge.getInstance().initialize()
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "SnowbirdBridge.initialize() failed")
+                // Continue; startServer may still surface a clearer error.
+            }
+
             val alreadyUp = isServerRunning()
             if (alreadyUp) {
                 Timber.d("Snowbird server already running; skipping start()")
@@ -142,17 +152,8 @@ class SnowbirdService : Service() {
 
     override fun onBind(intent: Intent?): IBinder? = null
 
-    /**
-     * Checks if a web server is available and responding with a 200 OK status.
-     * Throws exceptions on failure for better integration with retry mechanisms.
-     *
-     * @param url The URL to check
-     * @param timeout Optional timeout in milliseconds (default 5000ms)
-     * @throws ConnectException if the server refuses connection
-     * @throws SocketTimeoutException if the connection times out
-     * @throws IOException for other network-related errors
-     */
-    private suspend fun checkServerAvailability(url: String, timeout: Int = 1000) {
+    /** Checks if a URL is reachable and returns 2xx. Throws on failure. */
+    private suspend fun checkServerAvailability(url: String, timeout: Int = 8000) {
         withContext(Dispatchers.IO) {
             var connection: HttpURLConnection? = null
             try {
@@ -164,7 +165,7 @@ class SnowbirdService : Service() {
                 }
 
                 when (connection.responseCode) {
-                    HttpURLConnection.HTTP_OK -> return@withContext
+                    in 200..299 -> return@withContext
                     else -> throw IOException("Server returned ${connection.responseCode}")
                 }
             } catch (e: Exception) {
@@ -174,6 +175,12 @@ class SnowbirdService : Service() {
                 connection?.disconnect()
             }
         }
+    }
+
+    /** `/status` proves liveness; `/health/ready` proves backend initialization. */
+    private suspend fun checkFullReadiness() {
+        checkServerAvailability("http://localhost:8080/status")
+        checkServerAvailability("http://localhost:8080/health/ready", timeout = 8000)
     }
 
     private fun createNotification(text: String, withSound: Boolean = false): Notification {
@@ -208,7 +215,7 @@ class SnowbirdService : Service() {
         Timber.d("Starting polling")
         pollingJob?.cancel() // Cancel any existing polling
 
-        pollingJob = suspendToRetry { checkServerAvailability("http://localhost:8080/status") }
+        pollingJob = suspendToRetry { checkFullReadiness() }
             .retryWithScope(
                 scope = serviceScope,
                 config = RetryConfig(
@@ -220,7 +227,8 @@ class SnowbirdService : Service() {
                 shouldRetry = { error ->
                     when (error) {
                         is ConnectException,
-                        is SocketTimeoutException -> true
+                        is SocketTimeoutException,
+                        is IOException -> true
 
                         else -> false
                     }

--- a/docs/SnowbirdLifecycle.md
+++ b/docs/SnowbirdLifecycle.md
@@ -1,0 +1,33 @@
+# Snowbird Lifecycle (Android ↔ Local Rust Server)
+
+Quick reference for the startup/readiness and refresh issues seen in DWeb testing.
+
+## Startup flow
+
+1. `SnowbirdFragment` starts `SnowbirdService`.
+2. `SnowbirdService` calls `SnowbirdBridge.initialize()` then `startServer(...)`.
+3. Service marks connected only after both checks pass:
+   - `GET http://localhost:8080/status`
+   - `GET http://localhost:8080/health/ready`
+
+## Why this matters
+
+- `/status` means HTTP server is up.
+- `/health/ready` means Veilid/Iroh/Blobs init is complete.
+- Without the second check, UI can look connected while backend calls still fail.
+
+## Refresh guardrails
+
+- Filter refresh results to repos that belong to the selected group.
+- Surface refresh failures by category:
+  - `DHT_DISCOVERY` (for repo root hash lookup failures)
+  - `PEER_DOWNLOAD` (for peer download failures)
+  - `UNKNOWN`
+
+## Relevant files
+
+- `app/src/main/java/net/opendasharchive/openarchive/services/snowbird/service/SnowbirdService.kt`
+- `app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdRepoViewModel.kt`
+- `app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdGroupRepository.kt`
+- `app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdRepoRepository.kt`
+- `app/src/main/java/net/opendasharchive/openarchive/services/snowbird/SnowbirdFileRepository.kt`


### PR DESCRIPTION
- This PR is a reference patch based on findings from the DWeb issues document and recent save-dweb-backend and save-rust updates.
- This PR is intentionally a reference implementation for review and adaptation by the Android team.


  - Improves Snowbird startup readiness checks:
      - Requires both liveness and backend readiness before marking connected.
      - Uses /status + /health/ready polling path.
      - Keeps retry behavior for transient startup failures.
  - Adds request guardrails while service is not ready:
      - Group/repo/file repositories now short-circuit with a clear “server not ready” error when service is not connected.
  - Improves refresh correctness and diagnostics:
      - Filters refresh results to repos scoped to the selected group.
      - Classifies repo refresh failures into buckets (DHT_DISCOVERY, PEER_DOWNLOAD, UNKNOWN) for clearer troubleshooting.
  - Aligns upload response handling with latest Rust response shape:
      - Supports optional file_hash in upload result and uses it when present.
  - Adds concise lifecycle reference doc:
      - docs/SnowbirdLifecycle.md summarizing startup flow, readiness checks, and refresh guardrails.